### PR TITLE
Multiple ingests

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,5 @@
 [MESSAGES CONTROL]
-disable=missing-docstring,redefined-builtin,old-style-class,too-few-public-methods,too-many-arguments,no-self-use,fixme,line-too-long,not-context-manager,too-many-locals,too-many-return-statements
+disable=missing-docstring,redefined-builtin,old-style-class,too-few-public-methods,too-many-arguments,no-self-use,fixme,line-too-long,not-context-manager
 
 good-names=id,s3,of,e,_
 function-rgx=[a-z_][a-z0-9_]{2,60}$

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,5 @@
 [MESSAGES CONTROL]
-disable=missing-docstring,redefined-builtin,old-style-class,too-few-public-methods,too-many-arguments,no-self-use,fixme,line-too-long,not-context-manager
+disable=missing-docstring,redefined-builtin,old-style-class,too-few-public-methods,too-many-arguments,no-self-use,fixme,line-too-long,not-context-manager,too-many-locals,too-many-return-statements
 
 good-names=id,s3,of,e,_
 function-rgx=[a-z_][a-z0-9_]{2,60}$

--- a/conftest.py
+++ b/conftest.py
@@ -31,7 +31,7 @@ def generate_article():
 @pytest.yield_fixture
 def version_article():
     created_articles = []
-    def from_original_article(original_article, new_version, version_number_prefix='r'):
+    def from_original_article(original_article, new_version):
         article = original_article.new_version(version=new_version)
         created_articles.append(article)
         return article
@@ -42,6 +42,7 @@ def version_article():
 def modify_article():
     created_articles = []
     def from_original_article(original_article, replacements=None):
+        # TODO: rename to new_revision()
         article = original_article.new_release()
         article.replace_in_text(replacements if replacements else {})
         created_articles.append(article)

--- a/conftest.py
+++ b/conftest.py
@@ -42,8 +42,7 @@ def version_article():
 def modify_article():
     created_articles = []
     def from_original_article(original_article, replacements=None):
-        # TODO: rename to new_revision()
-        article = original_article.new_release()
+        article = original_article.new_revision()
         article.replace_in_text(replacements if replacements else {})
         created_articles.append(article)
         return article

--- a/conftest.py
+++ b/conftest.py
@@ -41,7 +41,7 @@ def version_article():
 @pytest.yield_fixture
 def modify_article():
     created_articles = []
-    def from_original_article(original_article, new_version, replacements=None):
+    def from_original_article(original_article, new_version=None, replacements=None):
         article = original_article.new_revision(version=new_version)
         article.replace_in_text(replacements if replacements else {})
         created_articles.append(article)

--- a/conftest.py
+++ b/conftest.py
@@ -32,20 +32,17 @@ def generate_article():
 def version_article():
     created_articles = []
     def from_original_article(original_article, new_version, version_number_prefix='r'):
-        article = original_article.new_version(version=new_version, version_number_prefix=version_number_prefix)
+        article = original_article.new_version(version=new_version)
         created_articles.append(article)
         return article
     yield from_original_article
     _clean_all(created_articles)
 
 @pytest.yield_fixture
-def silently_correct_article():
+def modify_article():
     created_articles = []
     def from_original_article(original_article, replacements=None):
-        article = original_article.new_version(
-            original_article.version() + 1,
-            version_number_prefix='r'
-        )
+        article = original_article.new_release()
         article.replace_in_text(replacements if replacements else {})
         created_articles.append(article)
         return article

--- a/conftest.py
+++ b/conftest.py
@@ -41,8 +41,8 @@ def version_article():
 @pytest.yield_fixture
 def modify_article():
     created_articles = []
-    def from_original_article(original_article, replacements=None):
-        article = original_article.new_revision()
+    def from_original_article(original_article, new_version, replacements=None):
+        article = original_article.new_revision(version=new_version)
         article.replace_in_text(replacements if replacements else {})
         created_articles.append(article)
         return article

--- a/spectrum/checks.py
+++ b/spectrum/checks.py
@@ -223,7 +223,7 @@ class DashboardArticleCheck:
             version_runs = article['versions'][version_key]['runs']
             run_suffix = ''
             if run:
-                matching_runs = [r for r_number, r in version_runs.iteritems() if r['run-id'] == run]
+                matching_runs = [r for _, r in version_runs.iteritems() if r['run-id'] == run]
                 if len(matching_runs) > 1:
                     raise RuntimeError("Too many runs matching run-id %s: %s", run, matching_runs)
                 if len(matching_runs) == 0:

--- a/spectrum/checks.py
+++ b/spectrum/checks.py
@@ -218,10 +218,8 @@ class DashboardArticleCheck:
                 return False
             run_suffix = ''
             if run:
-                matching_runs = [r for _, r in version_contents['runs'].iteritems() if r['run-id'] == run]
-                if len(matching_runs) > 1:
-                    raise RuntimeError("Too many runs matching run-id %s: %s", run, matching_runs)
-                if len(matching_runs) == 0:
+                run_contents = self._check_for_run(version_contents, run)
+                if not run_contents:
                     return False
                 run_suffix = " with run %s" % run
             LOGGER.info(
@@ -243,6 +241,14 @@ class DashboardArticleCheck:
         if version_key not in article['versions']:
             return False
         return article['versions'][version_key]
+
+    def _check_for_run(self, version_contents, run):
+        matching_runs = [r for _, r in version_contents['runs'].iteritems() if r['run-id'] == run]
+        if len(matching_runs) > 1:
+            raise RuntimeError("Too many runs matching run-id %s: %s", run, matching_runs)
+        if len(matching_runs) == 0:
+            return False
+        return matching_runs[0]
 
     def _is_last_event_error(self, id, version, run):
         url = self._article_api(id)

--- a/spectrum/generator.py
+++ b/spectrum/generator.py
@@ -36,7 +36,7 @@ def article_zip(template_id):
                 figure_names.append(match.groups()[0])
     LOGGER.info("Generated %s with figures %s", zip_filename, figure_names, extra={'id': id})
     has_pdf = len(glob.glob(template + "/*.pdf")) >= 1
-    return ArticleZip(id, zip_filename, generated_article_directory, release=1, version=1, figure_names=figure_names, has_pdf=has_pdf)
+    return ArticleZip(id, zip_filename, generated_article_directory, revision=1, version=1, figure_names=figure_names, has_pdf=has_pdf)
 
 def clean():
     for entry in glob.glob('/tmp/elife*'):
@@ -87,11 +87,11 @@ def _generate(filename, id, generated_article_directory, template_id):
     return target
 
 class ArticleZip:
-    def __init__(self, id, filename, directory, release, version, figure_names=None, has_pdf=False):
+    def __init__(self, id, filename, directory, revision, version, figure_names=None, has_pdf=False):
         self._id = id
         self._filename = filename
         self._directory = directory
-        self._release = release
+        self._revision = revision
         self._version = version
         self._figure_names = figure_names if figure_names else []
         self._has_pdf = has_pdf
@@ -117,22 +117,22 @@ class ArticleZip:
     def has_pdf(self):
         return self._has_pdf
 
-    def new_release(self):
-        new_release = self._release + 1
-        new_filename = re.sub(r'-(r|v)\d+.zip$', ('-r%s.zip' % new_release), self._filename)
+    def new_revision(self):
+        new_revision = self._revision + 1
+        new_filename = re.sub(r'-(r|v)\d+.zip$', ('-r%s.zip' % new_revision), self._filename)
         shutil.copy(self._filename, new_filename)
-        new_directory = re.sub(r'-(r|v)\d+$', ('-r%s' % new_release), self._directory)
+        new_directory = re.sub(r'-(r|v)\d+$', ('-r%s' % new_revision), self._directory)
         shutil.copytree(self._directory, new_directory)
-        return ArticleZip(self._id, new_filename, new_directory, new_release, self._version, self._figure_names, self._has_pdf)
+        return ArticleZip(self._id, new_filename, new_directory, new_revision, self._version, self._figure_names, self._has_pdf)
 
     def new_version(self, version):
         # what is changed is actually the "run"
-        new_release = self._release + 1
+        new_revision = self._revision + 1
         new_filename = re.sub(r'-(r|v)\d+.zip$', ('-v%s.zip' % version), self._filename)
         shutil.copy(self._filename, new_filename)
         new_directory = re.sub(r'-(r|v)\d+$', ('-v%s' % version), self._directory)
         shutil.copytree(self._directory, new_directory)
-        return ArticleZip(self._id, new_filename, new_directory, new_release, version, self._figure_names, self._has_pdf)
+        return ArticleZip(self._id, new_filename, new_directory, new_revision, version, self._figure_names, self._has_pdf)
 
     def replace_in_text(self, replacements):
         """Beware: violates immutability, as it modifies the file in place for performance reasons"""

--- a/spectrum/generator.py
+++ b/spectrum/generator.py
@@ -36,7 +36,7 @@ def article_zip(template_id):
                 figure_names.append(match.groups()[0])
     LOGGER.info("Generated %s with figures %s", zip_filename, figure_names, extra={'id': id})
     has_pdf = len(glob.glob(template + "/*.pdf")) >= 1
-    return ArticleZip(id, zip_filename, generated_article_directory, version=1, figure_names=figure_names, has_pdf=has_pdf)
+    return ArticleZip(id, zip_filename, generated_article_directory, release=1, version=1, figure_names=figure_names, has_pdf=has_pdf)
 
 def clean():
     for entry in glob.glob('/tmp/elife*'):
@@ -87,10 +87,11 @@ def _generate(filename, id, generated_article_directory, template_id):
     return target
 
 class ArticleZip:
-    def __init__(self, id, filename, directory, version, figure_names=None, has_pdf=False):
+    def __init__(self, id, filename, directory, release, version, figure_names=None, has_pdf=False):
         self._id = id
         self._filename = filename
         self._directory = directory
+        self._release = release
         self._version = version
         self._figure_names = figure_names if figure_names else []
         self._has_pdf = has_pdf
@@ -116,13 +117,22 @@ class ArticleZip:
     def has_pdf(self):
         return self._has_pdf
 
-    def new_version(self, version, version_number_prefix='r'):
-        # what is changed is actually the "run"
-        new_filename = re.sub(r'-(r|v)\d+.zip$', ('-%s%s.zip' % (version_number_prefix, version)), self._filename)
+    def new_release(self):
+        new_release = self._release + 1
+        new_filename = re.sub(r'-(r|v)\d+.zip$', ('-r%s.zip' % new_release), self._filename)
         shutil.copy(self._filename, new_filename)
-        new_directory = re.sub(r'-(r|v)\d+$', ('-%s%s' % (version_number_prefix, version)), self._directory)
+        new_directory = re.sub(r'-(r|v)\d+$', ('-r%s' % new_release), self._directory)
         shutil.copytree(self._directory, new_directory)
-        return ArticleZip(self._id, new_filename, new_directory, version, self._figure_names, self._has_pdf)
+        return ArticleZip(self._id, new_filename, new_directory, new_release, self._version, self._figure_names, self._has_pdf)
+
+    def new_version(self, version):
+        # what is changed is actually the "run"
+        new_release = self._release + 1
+        new_filename = re.sub(r'-(r|v)\d+.zip$', ('-v%s.zip' % version), self._filename)
+        shutil.copy(self._filename, new_filename)
+        new_directory = re.sub(r'-(r|v)\d+$', ('-v%s' % version), self._directory)
+        shutil.copytree(self._directory, new_directory)
+        return ArticleZip(self._id, new_filename, new_directory, new_release, version, self._figure_names, self._has_pdf)
 
     def replace_in_text(self, replacements):
         """Beware: violates immutability, as it modifies the file in place for performance reasons"""

--- a/spectrum/generator.py
+++ b/spectrum/generator.py
@@ -117,13 +117,17 @@ class ArticleZip:
     def has_pdf(self):
         return self._has_pdf
 
-    def new_revision(self):
+    def new_revision(self, version=None):
+        if version:
+            new_version = version
+        else:
+            new_version = self._version
         new_revision = self._revision + 1
         new_filename = re.sub(r'-(r|v)\d+.zip$', ('-r%s.zip' % new_revision), self._filename)
         shutil.copy(self._filename, new_filename)
         new_directory = re.sub(r'-(r|v)\d+$', ('-r%s' % new_revision), self._directory)
         shutil.copytree(self._directory, new_directory)
-        return ArticleZip(self._id, new_filename, new_directory, new_revision, self._version, self._figure_names, self._has_pdf)
+        return ArticleZip(self._id, new_filename, new_directory, new_revision, new_version, self._figure_names, self._has_pdf)
 
     def new_version(self, version):
         # what is changed is actually the "run"

--- a/spectrum/input.py
+++ b/spectrum/input.py
@@ -30,11 +30,12 @@ class Dashboard:
         body = {}
         body = {'articles': [{'id': id, 'version': version, 'run': run}]}
         response = requests.post(url, auth=(self._user, self._password), json=body, verify=False)
-        assert response.status_code == 200, ("Response status wass %s: %s" % (response.status_code, response.text))
+        assert response.status_code == 200, ("Response status was %s: %s" % (response.status_code, response.text))
         LOGGER.info(
-            "Pressed Publish for %s version %s on dashboard",
+            "Pressed Publish for %s version %s run %s on dashboard",
             url,
             version,
+            run,
             extra={'id': id}
         )
 

--- a/spectrum/test_article.py
+++ b/spectrum/test_article.py
@@ -26,7 +26,7 @@ def test_article_multiple_ingests_of_the_same_version(generate_article, modify_a
     run1 = _wait_for_publishable(article)
 
     run2_start = datetime.now()
-    modified_article = modify_article(article, {'cytomegalovirus': 'CYTOMEGALOVIRUS'})
+    modified_article = modify_article(article, replacements={'cytomegalovirus': 'CYTOMEGALOVIRUS'})
     _ingest(modified_article)
     (run2, ) = checks.EIF.of(id=article.id(), version=article.version(), last_modified_after=run2_start)
     checks.DASHBOARD.ready_to_publish(id=article.id(), version=article.version(), run=run2)
@@ -51,7 +51,7 @@ def test_article_silent_correction(generate_article, modify_article):
     article = generate_article(template_id)
     _ingest_and_publish(article)
     silent_correction_start = datetime.now()
-    silently_corrected_article = modify_article(article, {'cytomegalovirus': 'CYTOMEGALOVIRUS'})
+    silently_corrected_article = modify_article(article, replacements={'cytomegalovirus': 'CYTOMEGALOVIRUS'})
     _feed_silent_correction(silently_corrected_article)
     input.SILENT_CORRECTION.article(os.path.basename(silently_corrected_article.filename()))
     checks.API.wait_article(id=article.id(), title='Correction: Human CYTOMEGALOVIRUS IE1 alters the higher-order chromatin structure by targeting the acidic patch of the nucleosome')

--- a/spectrum/test_article.py
+++ b/spectrum/test_article.py
@@ -35,12 +35,11 @@ def test_article_multiple_ingests_of_the_same_version(generate_article, modify_a
     checks.API.wait_article(id=article.id(), title='Correction: Human CYTOMEGALOVIRUS IE1 alters the higher-order chromatin structure by targeting the acidic patch of the nucleosome')
 
 @pytest.mark.continuum
-def test_article_multiple_versions(generate_article, version_article):
+def test_article_multiple_versions(generate_article, modify_article):
     template_id = 15893
     article = generate_article(template_id)
     _ingest_and_publish(article)
-    # TODO: maybe use -r2? how does it detect a new version?
-    new_article = version_article(article, new_version=2)
+    new_article = modify_article(article, new_version=2)
     _ingest_and_publish(new_article)
 
 # this is a silent correction of a 'correction' article, don't be confused

--- a/spectrum/test_article.py
+++ b/spectrum/test_article.py
@@ -78,9 +78,8 @@ def _ingest(article):
 def _feed_silent_correction(article):
     input.SILENT_CORRECTION_BUCKET.upload(article.filename(), article.id())
 
-def _wait_for_publishable(article, last_modified_after=None):
-    (run, ) = checks.EIF.of(id=article.id(), version=article.version(), last_modified_after=last_modified_after)
-    # TODO use last_modified_after or someting similar everywhere
+def _wait_for_publishable(article):
+    (run, ) = checks.EIF.of(id=article.id(), version=article.version())
     for each in article.figure_names():
         checks.IMAGES_BOT_CDN.of(id=article.id(), figure_name=each, version=article.version())
         checks.IMAGES_PUBLISHED_CDN.of(id=article.id(), figure_name=each, version=article.version())
@@ -90,7 +89,6 @@ def _wait_for_publishable(article, last_modified_after=None):
         checks.PDF_BOT_CDN.of(id=article.id(), version=article.version())
         checks.PDF_PUBLISHED_CDN.of(id=article.id(), version=article.version())
         checks.PDF_DOWNLOAD_PUBLISHED_CDN.of(id=article.id(), version=article.version())
-    # TODO: check they have been modified here?
     checks.WEBSITE.unpublished(id=article.id(), version=article.version())
     checks.DASHBOARD.ready_to_publish(id=article.id(), version=article.version(), run=run)
     return run


### PR DESCRIPTION
The new test performs:
- ingest of a `*-r1.zip` file. This causes an `ingest` command from bot to lax.
- ingest of a `*-r2.zip` with the same article and an modification in the text. This causes another `ingest` command from bot to lax.
- publishing the run resulting from `*-r2.zip`. This causes a `publish` command from bot to lax.
- verifying the edit of `*-r2.zip` is visible through Lax's API.

However, this already passes so it does not reproduce https://github.com/elifesciences/lax/pull/54 because that problem is not fixed on the `develop` branch.
@lsh-0 any pointers on how to reproduce that particular problem?