### PR TITLE
Expanding test to also check Journal article page

### DIFF
--- a/spectrum/test_article.py
+++ b/spectrum/test_article.py
@@ -100,14 +100,18 @@ def test_searching_for_a_new_article(generate_article, modify_article):
     checks.JOURNAL.search(invented_word, count=1)
 
 @pytest.mark.recommendations
-def test_recommendations_for_a_new_article(generate_article):
+def test_recommendations_for_new_articles(generate_article):
     template_id = 15893
-    article = generate_article(template_id)
-    _ingest_and_publish(article)
-    result = checks.API.wait_recommendations(article.id())
-    assert len(result['items']) >= 1
-    article_from_api = checks.API.wait_article(id=article.id())
-    checks.JOURNAL.article(id=article.id(), volume=article_from_api['volume'])
+    first_article = generate_article(template_id)
+    _ingest_and_publish(first_article)
+    second_article = generate_article(template_id)
+    _ingest_and_publish(second_article)
+
+    for article in [first_article, second_article]:
+        result = checks.API.wait_recommendations(article.id())
+        assert len(result['items']) >= 1
+        article_from_api = checks.API.wait_article(id=article.id())
+        checks.JOURNAL.article(id=article.id(), volume=article_from_api['volume'])
 
 def _ingest(article):
     input.PRODUCTION_BUCKET.upload(article.filename(), article.id())

--- a/spectrum/test_article.py
+++ b/spectrum/test_article.py
@@ -106,6 +106,8 @@ def test_recommendations_for_a_new_article(generate_article):
     _ingest_and_publish(article)
     result = checks.API.wait_recommendations(article.id())
     assert len(result['items']) >= 1
+    article_from_api = checks.API.wait_article(id=article.id())
+    checks.JOURNAL.article(id=article.id(), volume=article_from_api['volume'])
 
 def _ingest(article):
     input.PRODUCTION_BUCKET.upload(article.filename(), article.id())


### PR DESCRIPTION
Would be better if we publish two articles, and one recommends the other. However, this tests will be running in parallel with many others so it cannot rely on "recommend the latest" rules.

Which rules could be used to have a deterministic result like:
- I publish 1
- I publish 2
- no matter what else is happening around, 2 recommends 1 (or at least it recommends 1 plus other stuff)
?