### PR TITLE
Journal CMS new Drupal and IIIF changes

### DIFF
--- a/spectrum/input.py
+++ b/spectrum/input.py
@@ -110,6 +110,7 @@ class JournalCmsSession:
     def create_article_fragment(self, id, image):
         create_url = "%s/admin/structure/article_fragment/add" % self._host
         create_page = self._browser.get(create_url)
+        assert create_page.status_code == 200, "Response status of %s was: %s\nBody: %s" % (create_url, create_page.status_code, create_page.content)
         form = mechanicalsoup.Form(create_page.soup.form)
         form.input({'name[0][value]': id})
         form.attach({'files[image_0]': image})

--- a/spectrum/test_article.py
+++ b/spectrum/test_article.py
@@ -146,7 +146,7 @@ def test_adding_article_fragment(generate_article):
     # TODO: caching problems
     article = checks.API.article(article.id())
     # TODO: transition to IIIF and use a IiifCheck object
-    image_url = article['image']['banner']['sizes']['2:1']['1800']
+    image_url = article['image']['banner']['source']['uri']
     response = requests.head(image_url)
     checks.LOGGER.info("Found %s: %s", image_url, response.status_code)
     assert response.status_code == 200, "Image %s is not loading" % image_url

--- a/spectrum/test_journal_cms.py
+++ b/spectrum/test_journal_cms.py
@@ -23,7 +23,7 @@ def test_content_type_propagates_to_other_services():
     id = result['items'][0]['id']
     blog_article = checks.API.blog_article(id)
     # TODO: transition to IIIF and use a IiifCheck object
-    image_url = blog_article['image']['banner']['sizes']['2:1']['1800']
+    image_url = blog_article['image']['banner']['source']['uri']
     response = requests.head(image_url)
     checks.LOGGER.info("Found %s: %s", image_url, response.status_code)
     assert response.status_code == 200, "Image %s is not loading" % image_url


### PR DESCRIPTION
- New schema in IIIF of blog articles
- Updated other journal-cms image check to target IIIF, foreseeing it will  break
- Failing fast on article fragments: if form doesn't load, stop the test

One of the two failing tests passes, while the other tries to load `/admin/structure/article_fragment/add` and gets a 500 saying
```
The website encountered an unexpected error. Please try again later.
```
The PHP error log shows:
```
[13-Apr-2017 08:03:18 UTC] Uncaught PHP Exception Drupal\Component\Plugin\Exception\PluginNotFoundException: "The "" entity type does not exist." at /ext/srv/journal-cms/web/core/lib/Drupal/Core/Entity/EntityTypeManager.php line 133
```
when that happens.

/cc @nlisgo 