### PR TITLE
Load testing Journal

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,10 +1,7 @@
-import logging
-import os
 import sys
 
 import pytest
 from spectrum import generator
-from spectrum import logger
 # so that other processes run by xdist can still print
 # http://stackoverflow.com/questions/27006884/pytest-xdist-without-capturing-output
 # https://github.com/pytest-dev/pytest/issues/680
@@ -56,8 +53,3 @@ def _clean_all(created_articles):
     for article in created_articles:
         article.clean()
 
-# pytest does not allow to read a cli argument globally, but
-# only from a test or a fixture afaik
-# so, workaround "trying hard to be an extensible tool and failing at it"
-LOG_LEVEL = os.environ.get('SPECTRUM_LOG_LEVEL', 'INFO')
-logger.set_logging_level(getattr(logging, LOG_LEVEL))

--- a/load_journal.py
+++ b/load_journal.py
@@ -2,5 +2,5 @@ from spectrum import load
 
 if __name__ == '__main__':
     while True:
-        load.LOGGER.error("New run")
+        load.LOGGER.info("New run")
         load.JOURNAL_ALL.run()

--- a/load_journal.py
+++ b/load_journal.py
@@ -1,5 +1,8 @@
-from spectrum import load
+from spectrum import load, logger
+
+LOGGER = logger.logger(__name__)
 
 if __name__ == '__main__':
     while True:
+        LOGGER.info("New run")
         load.JOURNAL_ALL.run()

--- a/load_journal.py
+++ b/load_journal.py
@@ -2,4 +2,4 @@ from spectrum import load
 
 if __name__ == '__main__':
     while True:
-        load.JOURNAL_SEARCH.run()
+        load.JOURNAL_ALL.run()

--- a/load_journal.py
+++ b/load_journal.py
@@ -1,8 +1,6 @@
-from spectrum import load, logger
-
-LOGGER = logger.logger(__name__)
+from spectrum import load
 
 if __name__ == '__main__':
     while True:
-        LOGGER.info("New run")
+        load.LOGGER.error("New run")
         load.JOURNAL_ALL.run()

--- a/load_journal.py
+++ b/load_journal.py
@@ -1,0 +1,5 @@
+from spectrum import load
+
+if __name__ == '__main__':
+    while True:
+        load.JOURNAL_SEARCH.run()

--- a/spectrum/checks.py
+++ b/spectrum/checks.py
@@ -813,6 +813,32 @@ JOURNAL = JournalCheck(
 JOURNAL_CDN = JournalCheck(
     host=SETTINGS['journal_cdn_host']
 )
+JOURNAL_GENERIC_PATHS = [
+    "/about",
+    "/about/early-career",
+    "/about/innovation",
+    "/about/openness",
+    "/about/peer-review",
+    "/alerts",
+    "/annual-reports",
+    "/archive/2016",
+    "/community",
+    "/contact",
+    "/for-the-press",
+    "/resources",
+    "/terms",
+    #/who-we-work-with
+]
+JOURNAL_LISTING_PATHS = [
+    '/articles/correction',
+    '/collections',
+    '/inside-elife',
+    '/labs',
+    '/podcast',
+    '/subjects',
+]
+
+
 GITHUB_XML = GithubCheck(
     repo_url=SETTINGS['github_article_xml_repository_url']
 )

--- a/spectrum/checks.py
+++ b/spectrum/checks.py
@@ -548,7 +548,8 @@ class JournalCheck:
         response = requests.get(url)
         _assert_status_code(response, 200, url)
         _assert_all_resources_of_page_load(response.content, self._host)
-        _assert_count(response.content, class_='teaser', count=count)
+        if count is not None:
+            _assert_count(response.content, class_='teaser', count=count)
 
     def homepage(self):
         return self.generic("/")

--- a/spectrum/checks.py
+++ b/spectrum/checks.py
@@ -573,7 +573,9 @@ class JournalCheck:
         teaser_a_tags = soup.select("div.teaser .teaser__header_text_link")
         teaser_links = [a['href'] for a in teaser_a_tags]
         LOGGER.info("Loaded %s, found links: %s", path, teaser_links)
-        return teaser_links
+        pager_a_tags = soup.select(".pager a")
+        pager_links = [a['href'] for a in pager_a_tags]
+        return teaser_links, pager_links
 
     def _persistently_get(self, url):
         response = requests.get(url)

--- a/spectrum/checks.py
+++ b/spectrum/checks.py
@@ -626,7 +626,9 @@ class JournalCheck:
     def _download_links(self, body):
         soup = BeautifulSoup(body, "html.parser")
         figure_download_links = [a.get('href') for a in soup.select(".asset-viewer-inline__download_all_link")]
-        pdf_download_links = [a.get('href') for a in soup.select("#downloads a")]
+        # TODO: filter to get only the downloads we want
+        #pdf_download_links = [a.get('href') for a in soup.select("#downloads a")]
+        pdf_download_links = []
         return figure_download_links + pdf_download_links
 
 

--- a/spectrum/checks.py
+++ b/spectrum/checks.py
@@ -827,7 +827,7 @@ JOURNAL_GENERIC_PATHS = [
     "/for-the-press",
     "/resources",
     "/terms",
-    #/who-we-work-with
+    "/who-we-work-with",
 ]
 JOURNAL_LISTING_PATHS = [
     '/articles/correction',

--- a/spectrum/checks.py
+++ b/spectrum/checks.py
@@ -565,7 +565,7 @@ class JournalCheck:
     def generic(self, path):
         url = _build_url(path, self._host)
         LOGGER.info("Loading %s", url)
-        response = requests.get(url)
+        response = self._persistently_get(url)
         _assert_status_code(response, 200, url)
         match = re.match("^"+self._host, response.url)
         if match:

--- a/spectrum/checks.py
+++ b/spectrum/checks.py
@@ -570,12 +570,21 @@ class JournalCheck:
     def listing(self, path):
         body = self.generic(path)
         soup = BeautifulSoup(body, "html.parser")
+        # TODO: drop div
         teaser_a_tags = soup.select("div.teaser .teaser__header_text_link")
         teaser_links = [a['href'] for a in teaser_a_tags]
-        LOGGER.info("Loaded %s, found links: %s", path, teaser_links)
+        LOGGER.info("Loaded listing %s, found links: %s", path, teaser_links)
         pager_a_tags = soup.select(".pager a")
         pager_links = [a['href'] for a in pager_a_tags]
         return teaser_links, pager_links
+
+    def listing_of_listing(self, path):
+        body = self.generic(path)
+        soup = BeautifulSoup(body, "html.parser")
+        a_tags = soup.select(".block_link .block-link__link")
+        links = [a['href'] for a in a_tags]
+        LOGGER.info("Loaded listing of listing %s, found links: %s", path, links)
+        return links
 
     def _persistently_get(self, url):
         response = requests.get(url)
@@ -814,30 +823,31 @@ JOURNAL_CDN = JournalCheck(
     host=SETTINGS['journal_cdn_host']
 )
 JOURNAL_GENERIC_PATHS = [
-    "/about",
-    "/about/early-career",
-    "/about/innovation",
-    "/about/openness",
-    "/about/peer-review",
-    "/alerts",
-    "/archive/2016",
-    "/contact",
-    "/for-the-press",
-    "/resources",
-    "/terms",
-    "/who-we-work-with",
+    '/about',
+    '/about/early-career',
+    '/about/innovation',
+    '/about/openness',
+    '/about/peer-review',
+    '/alerts',
+    '/contact',
+    '/for-the-press',
+    '/resources',
+    '/terms',
+    '/who-we-work-with',
 ]
 JOURNAL_LISTING_PATHS = [
-    "/annual-reports",
+    '/annual-reports',
     '/articles/correction',
     '/collections',
     "/community",
     '/inside-elife',
     '/labs',
     '/podcast',
+]
+JOURNAL_LISTING_OF_LISTING_PATHS = [
+    '/archive/2016',
     '/subjects',
 ]
-
 
 GITHUB_XML = GithubCheck(
     repo_url=SETTINGS['github_article_xml_repository_url']

--- a/spectrum/checks.py
+++ b/spectrum/checks.py
@@ -728,7 +728,7 @@ def _assert_all_resources_of_page_load(html_content, host, resource_checking_met
             srcset = media_source.get("srcset")
             if srcset:
                 resources.extend(_srcset_values(srcset))
-        return resources
+        return list(set(resources))
     soup = BeautifulSoup(html_content, "html.parser")
     resources = _resources_from(soup)
     LOGGER.info("Found resources %s", pformat(resources), extra=extra)

--- a/spectrum/checks.py
+++ b/spectrum/checks.py
@@ -520,6 +520,14 @@ class ApiCheck:
         return final_headers
 
 class JournalCheck:
+    CSS_FIGURES_LINK = 'view-selector__link--figures'
+    CSS_TEASER_LINK = '.teaser__header_text_link'
+    CSS_CAROUSEL_LINK = '.carousel-item__title_link'
+    CSS_BLOCK_LINK = '.block-link .block-link__link'
+    CSS_PAGER_LINK = '.pager a'
+    CSS_ASSET_VIEWER_DOWNLOAD_LINK = '.asset-viewer-inline__download_all_link'
+    CSS_DOWNLOAD_LINK = '#downloads a'
+
     def __init__(self, host, resource_checking_method='head'):
         self._host = host
         self._resource_checking_method = resource_checking_method
@@ -533,10 +541,9 @@ class JournalCheck:
             url = "%sv%s" % (url, version)
         LOGGER.info("Loading %s", url, extra={'id':id})
         body = self.generic(url)
-        figures_link_selector = 'view-selector__link--figures'
-        figures_link = self._link(body, figures_link_selector)
+        figures_link = self._link(body, self.CSS_FIGURES_LINK)
         if has_figures:
-            assert figures_link is not None, "Cannot find figures link with selector %s" % figures_link_selector
+            assert figures_link is not None, "Cannot find figures link with selector %s" % self.CSS_FIGURES_LINK
             figures_url = _build_url(figures_link, self._host)
             LOGGER.info("Loading %s", figures_url, extra={'id':id})
         return body
@@ -546,8 +553,7 @@ class JournalCheck:
         LOGGER.info("Loading %s", url)
         body = self.generic(url)
         soup = BeautifulSoup(body, "html.parser")
-        # TODO: duplication of teaser_links logic
-        teaser_links = [a['href'] for a in soup.select('.teaser__header_text_link')]
+        teaser_links = [a['href'] for a in soup.select(self.CSS_TEASER_LINK)]
         if count is not None:
             assert len(teaser_links) == count, "There are only %d search results" % len(teaser_links)
         return teaser_links
@@ -555,8 +561,8 @@ class JournalCheck:
     def homepage(self):
         body = self.generic("/")
         soup = BeautifulSoup(body, "html.parser")
-        carousel_links = [a['href'] for a in soup.select('.carousel-item__title_link')]
-        teaser_links = [a['href'] for a in soup.select('.teaser__header_text_link')]
+        carousel_links = [a['href'] for a in soup.select(self.CSS_CAROUSEL_LINK)]
+        teaser_links = [a['href'] for a in soup.select(self.CSS_TEASER_LINK)]
         links = carousel_links + teaser_links
         return links
 
@@ -579,17 +585,17 @@ class JournalCheck:
     def listing(self, path):
         body = self.generic(path)
         soup = BeautifulSoup(body, "html.parser")
-        teaser_a_tags = soup.select(".teaser .teaser__header_text_link")
+        teaser_a_tags = soup.select(self.CSS_TEASER_LINK)
         teaser_links = [a['href'] for a in teaser_a_tags]
         LOGGER.info("Loaded listing %s, found links: %s", path, teaser_links)
-        pager_a_tags = soup.select(".pager a")
+        pager_a_tags = soup.select(self.CSS_PAGER_LINK)
         pager_links = [a['href'] for a in pager_a_tags]
         return teaser_links, pager_links
 
     def listing_of_listing(self, path):
         body = self.generic(path)
         soup = BeautifulSoup(body, "html.parser")
-        a_tags = soup.select(".block-link .block-link__link")
+        a_tags = soup.select(self.CSS_BLOCK_LINK)
         links = [a['href'] for a in a_tags]
         LOGGER.info("Loaded listing of listing %s, found links: %s", path, links)
         return links
@@ -620,8 +626,8 @@ class JournalCheck:
 
     def _download_links(self, body):
         soup = BeautifulSoup(body, "html.parser")
-        figure_download_links = [a.get('href') for a in soup.select(".asset-viewer-inline__download_all_link")]
-        pdf_download_links = [a.get('href') for a in soup.select("#downloads a") if a.text in ['Article PDF', 'Figures PDF']]
+        figure_download_links = [a.get('href') for a in soup.select(self.CSS_ASSET_VIEWER_DOWNLOAD_LINK)]
+        pdf_download_links = [a.get('href') for a in soup.select(self.CSS_DOWNLOAD_LINK) if a.text in ['Article PDF', 'Figures PDF']]
         return figure_download_links + pdf_download_links
 
 

--- a/spectrum/checks.py
+++ b/spectrum/checks.py
@@ -696,8 +696,13 @@ def _log_connection_error(e):
     LOGGER.debug("Connection error, will retry: %s", e)
 
 def _assert_status_code(response, expected_status_code, url):
-    assert response.status_code == expected_status_code, \
-        "Response from %s had status %d, body %s" % (url, response.status_code, response.content)
+    try:
+        assert response.status_code == expected_status_code, \
+            "Response from %s had status %d, body %s" % (url, response.status_code, response.content)
+    except UnicodeDecodeError:
+        LOGGER.exception("Unicode error on %s (status code %s)", url, response.status_code)
+        print response.content
+        raise RuntimeError("Could not decode response from %s (status code %s)" % (url, response.status_code))
 
 RESOURCE_CACHE = {}
 

--- a/spectrum/checks.py
+++ b/spectrum/checks.py
@@ -820,9 +820,7 @@ JOURNAL_GENERIC_PATHS = [
     "/about/openness",
     "/about/peer-review",
     "/alerts",
-    "/annual-reports",
     "/archive/2016",
-    "/community",
     "/contact",
     "/for-the-press",
     "/resources",
@@ -830,8 +828,10 @@ JOURNAL_GENERIC_PATHS = [
     "/who-we-work-with",
 ]
 JOURNAL_LISTING_PATHS = [
+    "/annual-reports",
     '/articles/correction',
     '/collections',
+    "/community",
     '/inside-elife',
     '/labs',
     '/podcast',

--- a/spectrum/checks.py
+++ b/spectrum/checks.py
@@ -561,7 +561,12 @@ class JournalCheck:
             _assert_count(response.content, class_='teaser', count=count)
 
     def homepage(self):
-        return self.generic("/")
+        body = self.generic("/")
+        soup = BeautifulSoup(body, "html.parser")
+        carousel_links = [a['href'] for a in soup.select('.carousel-item__title_link')]
+        teaser_links = [a['href'] for a in soup.select('.teaser__header_text_link')]
+        links = carousel_links + teaser_links
+        return links
 
     def magazine(self):
         return self.generic("/magazine")

--- a/spectrum/checks.py
+++ b/spectrum/checks.py
@@ -701,7 +701,8 @@ def _assert_all_resources_of_page_load(html_content, host, **extra):
             if script.get("src"):
                 resources.append(script.get("src"))
         for link in soup.find_all("link"):
-            resources.append(link.get("href"))
+            if "canonical" not in link.get("rel"):
+                resources.append(link.get("href"))
         for video in soup.find_all("video"):
             resources.append(video.get("poster"))
         for media_source in soup.find_all("source"):
@@ -711,7 +712,6 @@ def _assert_all_resources_of_page_load(html_content, host, **extra):
         return resources
     soup = BeautifulSoup(html_content, "html.parser")
     resources = _resources_from(soup)
-    # TODO: resources seems to contain a link to its own page as the last element?
     LOGGER.info("Found resources %s", pformat(resources), extra=extra)
     for path in resources:
         if path is None:

--- a/spectrum/checks.py
+++ b/spectrum/checks.py
@@ -721,6 +721,7 @@ def _assert_all_resources_of_page_load(html_content, host, **extra):
             LOGGER.debug("Cached %s: %s", url, RESOURCE_CACHE[url], extra=extra)
         else:
             LOGGER.debug("Loading resource %s", url, extra=extra)
+            # TODO: support GET when needed
             response = requests.head(url)
             _assert_status_code(response, 200, url)
             RESOURCE_CACHE[url] = response.status_code

--- a/spectrum/checks.py
+++ b/spectrum/checks.py
@@ -532,24 +532,19 @@ class JournalCheck:
         if version:
             url = "%sv%s" % (url, version)
         LOGGER.info("Loading %s", url, extra={'id':id})
-        response = self._persistently_get(url)
-        _assert_status_code(response, 200, url)
-        self._assert_all_resources_of_page_load(response.content, id=id)
+        body = self.generic(url)
         download_links = []
-        download_links.extend(self._download_links(response.content))
+        download_links.extend(self._download_links(body))
         figures_link_selector = 'view-selector__link--figures'
-        figures_link = self._link(response.content, figures_link_selector)
+        figures_link = self._link(body, figures_link_selector)
         if has_figures:
             assert figures_link is not None, "Cannot find figures link with selector %s" % figures_link_selector
             figures_url = _build_url(figures_link, self._host)
             LOGGER.info("Loading %s", figures_url, extra={'id':id})
-            response = self._persistently_get(figures_url)
-            _assert_status_code(response, 200, figures_url)
-            self._assert_all_resources_of_page_load(response.content, id=id)
-            download_links.extend(self._download_links(response.content))
+            download_links.extend(self._download_links(body))
         LOGGER.info("Found download links: %s", pformat(download_links))
         self._assert_all_load(download_links)
-        return response.content
+        return body
 
     def search(self, query, count=1):
         url = _build_url("/search?for=%s" % query, self._host)
@@ -627,7 +622,7 @@ class JournalCheck:
         soup = BeautifulSoup(body, "html.parser")
         figure_download_links = [a.get('href') for a in soup.select(".asset-viewer-inline__download_all_link")]
         # TODO: filter to get only the downloads we want
-        #pdf_download_links = [a.get('href') for a in soup.select("#downloads a")]
+        #pdf_download_links = [a.get('href') for a in soup.select("#downloads a") if a.text in ['Article PDF', 'Figures PDF']]
         pdf_download_links = []
         return figure_download_links + pdf_download_links
 

--- a/spectrum/checks.py
+++ b/spectrum/checks.py
@@ -621,8 +621,6 @@ class JournalCheck:
     def _download_links(self, body):
         soup = BeautifulSoup(body, "html.parser")
         figure_download_links = [a.get('href') for a in soup.select(".asset-viewer-inline__download_all_link")]
-        # TODO: filter to get only the downloads we want
-        pdf_download_links = []
         pdf_download_links = [a.get('href') for a in soup.select("#downloads a") if a.text in ['Article PDF', 'Figures PDF']]
         return figure_download_links + pdf_download_links
 

--- a/spectrum/checks.py
+++ b/spectrum/checks.py
@@ -751,7 +751,7 @@ def _assert_all_resources_of_page_load(html_content, host, resource_checking_met
 def _assert_all_load(resources, host, resource_checking_method='head', **extra):
     for path in resources:
         if path is None:
-            # TODO; warning?
+            LOGGER.warning("empty path in resources: %s", resources)
             continue
         url = _build_url(path, host)
         if url in RESOURCE_CACHE and resource_checking_method == 'head':

--- a/spectrum/checks.py
+++ b/spectrum/checks.py
@@ -570,8 +570,7 @@ class JournalCheck:
     def listing(self, path):
         body = self.generic(path)
         soup = BeautifulSoup(body, "html.parser")
-        # TODO: drop div
-        teaser_a_tags = soup.select("div.teaser .teaser__header_text_link")
+        teaser_a_tags = soup.select(".teaser .teaser__header_text_link")
         teaser_links = [a['href'] for a in teaser_a_tags]
         LOGGER.info("Loaded listing %s, found links: %s", path, teaser_links)
         pager_a_tags = soup.select(".pager a")

--- a/spectrum/checks.py
+++ b/spectrum/checks.py
@@ -544,12 +544,9 @@ class JournalCheck:
     def search(self, query, count=1):
         url = _build_url("/search?for=%s" % query, self._host)
         LOGGER.info("Loading %s", url)
-        # TODO: use self.generic here and wherever else is needed
-        response = requests.get(url)
-        _assert_status_code(response, 200, url)
-        self._assert_all_resources_of_page_load(response.content)
+        body = self.generic(url)
         if count is not None:
-            _assert_count(response.content, class_='teaser', count=count)
+            _assert_count(body, class_='teaser', count=count)
 
     def homepage(self):
         body = self.generic("/")

--- a/spectrum/checks.py
+++ b/spectrum/checks.py
@@ -581,7 +581,7 @@ class JournalCheck:
     def listing_of_listing(self, path):
         body = self.generic(path)
         soup = BeautifulSoup(body, "html.parser")
-        a_tags = soup.select(".block_link .block-link__link")
+        a_tags = soup.select(".block-link .block-link__link")
         links = [a['href'] for a in a_tags]
         LOGGER.info("Loaded listing of listing %s, found links: %s", path, links)
         return links
@@ -712,6 +712,7 @@ def _assert_all_resources_of_page_load(html_content, host, **extra):
         return resources
     soup = BeautifulSoup(html_content, "html.parser")
     resources = _resources_from(soup)
+    # TODO: resources seems to contain a link to its own page as the last element?
     LOGGER.info("Found resources %s", pformat(resources), extra=extra)
     for path in resources:
         if path is None:

--- a/spectrum/input.py
+++ b/spectrum/input.py
@@ -187,8 +187,10 @@ def _journal_cms_page_title(soup):
     #<h1 class="js-quickedit-page-title title page-title">alfred</h1>
     return soup.find("h1", {"class": "page-title"}).text.strip()
 
-def invented_word(length=30):
-    return ''.join(random.choice(string.ascii_lowercase + string.digits) for _ in range(length))
+def invented_word(length=30, characters=None):
+    if not characters:
+        characters = string.ascii_lowercase + string.digits
+    return ''.join(random.choice(characters) for _ in range(length))
 
 PRODUCTION_BUCKET = InputBucket(aws.S3, SETTINGS['bucket_input'])
 SILENT_CORRECTION_BUCKET = InputBucket(aws.S3, SETTINGS['bucket_silent_corrections'])

--- a/spectrum/input.py
+++ b/spectrum/input.py
@@ -187,9 +187,8 @@ def _journal_cms_page_title(soup):
     #<h1 class="js-quickedit-page-title title page-title">alfred</h1>
     return soup.find("h1", {"class": "page-title"}).text.strip()
 
-
-def invented_word():
-    return ''.join(random.choice(string.ascii_lowercase + string.digits) for _ in range(30))
+def invented_word(length=30):
+    return ''.join(random.choice(string.ascii_lowercase + string.digits) for _ in range(length))
 
 PRODUCTION_BUCKET = InputBucket(aws.S3, SETTINGS['bucket_input'])
 SILENT_CORRECTION_BUCKET = InputBucket(aws.S3, SETTINGS['bucket_silent_corrections'])

--- a/spectrum/load.py
+++ b/spectrum/load.py
@@ -16,15 +16,25 @@ class JournalListing():
         self._journal = journal
         self._path = path
 
-    def run(self)
+    def run(self):
         LOGGER.info("Loading %s", self._path)
         items = self._journal.listing(self._path)
         for i in items:
+            LOGGER.info("Loading %s", i)
             self._journal.generic(i)
         # TODO: next page
 
+class AllOf():
+    def __init__(self, actions):
+        self._actions = actions
+
+    def run(self):
+        # TODO: probability to weight actions
+        for a in self._actions:
+            a.run()
         
 JOURNAL_SEARCH = JournalSearch(checks.JOURNAL)
 JOURNAL_LISTINGS = [
     JournalListing(checks.JOURNAL, '/subjects/neuroscience')
 ]
+JOURNAL_ALL = AllOf([JOURNAL_SEARCH]+JOURNAL_LISTINGS)

--- a/spectrum/load.py
+++ b/spectrum/load.py
@@ -19,9 +19,9 @@ class JournalListing():
     def run(self):
         LOGGER.info("Loading %s", self._path)
         items = self._journal.listing(self._path)
-        for i in items:
-            LOGGER.info("Loading %s", i)
-            self._journal.generic(i)
+        for item in items:
+            LOGGER.info("Loading %s", item)
+            self._journal.generic(item)
         # TODO: next page
 
 class AllOf():
@@ -30,9 +30,9 @@ class AllOf():
 
     def run(self):
         # TODO: probability to weight actions
-        for a in self._actions:
-            a.run()
-        
+        for action in self._actions:
+            action.run()
+
 JOURNAL_SEARCH = JournalSearch(checks.JOURNAL)
 JOURNAL_LISTINGS = [
     JournalListing(checks.JOURNAL, '/subjects/neuroscience')

--- a/spectrum/load.py
+++ b/spectrum/load.py
@@ -20,6 +20,7 @@ class Queue():
 
     def restart_if_empty(self):
         if len(self._contents) == 0:
+            LOGGER.warning("Need to refill queue with %s", self._seed)
             self._contents = self._seed
 
     def __len__(self):
@@ -68,7 +69,6 @@ class JournalListing():
                 self._items.enqueue(item)
             for link in links:
                 self._pages.enqueue(link)
-        # TODO: really necessary?
         self._pages.restart_if_empty()
 
     def __str__(self):

--- a/spectrum/load.py
+++ b/spectrum/load.py
@@ -5,7 +5,7 @@ from spectrum import logger, input, checks
 LOGGER = logger.logger(__name__)
 
 class Queue():
-    def __init__(self, contents = None):
+    def __init__(self, contents=None):
         self._contents = contents if contents else []
         self._seed = self._contents
 

--- a/spectrum/load.py
+++ b/spectrum/load.py
@@ -161,9 +161,9 @@ JOURNAL_PAGES = [
 JOURNAL_ALL = AllOf(
     [
         (JournalSearch(JOURNAL), 8),
-        #(JournalHomepage(JOURNAL), 8),
+        (JournalHomepage(JOURNAL), 8),
     ]
-    #+JOURNAL_LISTINGS
-    #+JOURNAL_LISTINGS_OF_LISTINGS
-    #+JOURNAL_PAGES
+    +JOURNAL_LISTINGS
+    +JOURNAL_LISTINGS_OF_LISTINGS
+    +JOURNAL_PAGES
 )

--- a/spectrum/load.py
+++ b/spectrum/load.py
@@ -66,17 +66,20 @@ class JournalListingOfListing():
     def __init__(self, journal, path):
         self._journal = journal
         self._path = path
+        self._listings = Queue()
 
     def run(self):
-        LOGGER.info("Loading listing of listing %s", self._path)
-        listings = AllOf([
-            (JournalListing(self._journal, item), 1)
-            for item in self._journal.listing_of_listing(self._path)
-        ])
-        listings.run()
+        if len(self._listings):
+            listing = self._listings.dequeue()
+            listing.run()
+            self._listings.enqueue(listing)
+        else:
+            LOGGER.info("Loading listing of listing %s", self._path)
+            for listing in self._journal.listing_of_listing(self._path):
+                self._listings.enqueue(JournalListing(self._journal, listing))
 
     def __str__(self):
-        return "JournalListingOfListing(%s)" % self._path
+        return "JournalListingOfListing(%s, listings queue length %s)" % (self._path, len(self._listings))
 
 class JournalPage():
     def __init__(self, journal, path):
@@ -143,7 +146,7 @@ JOURNAL_ALL = AllOf(
         #(JournalSearch(JOURNAL), 8),
         #(JournalHomepage(JOURNAL), 8),
     ]
-    +JOURNAL_LISTINGS
-    #+JOURNAL_LISTINGS_OF_LISTINGS
+    #+JOURNAL_LISTINGS
+    +JOURNAL_LISTINGS_OF_LISTINGS
     #+JOURNAL_PAGES
 )

--- a/spectrum/load.py
+++ b/spectrum/load.py
@@ -28,11 +28,20 @@ class JournalSearch():
     def __init__(self, journal, length=3):
         self._journal = journal
         self._length = length
+        self._results = Queue()
 
     def run(self):
-        word = input.invented_word(self._length)
-        LOGGER.info("Searching for %s", word)
-        self._journal.search(word, count=None)
+        if len(self._results):
+            result = self._results.dequeue()
+            LOGGER.info("Loading search result %s", result)
+            self._journal.generic(result)
+        else:
+            word = input.invented_word(self._length)
+            LOGGER.info("Searching for %s", word)
+            results = self._journal.search(word, count=None)
+            # TODO: Queue.enqueue_all
+            for result in results:
+                self._results.enqueue(result)
 
     def __str__(self):
         return "JournalSearch(length=%s)" % self._length
@@ -149,8 +158,8 @@ JOURNAL_PAGES = [
 ]
 JOURNAL_ALL = AllOf(
     [
-        #(JournalSearch(JOURNAL), 8),
-        (JournalHomepage(JOURNAL), 8),
+        (JournalSearch(JOURNAL), 8),
+        #(JournalHomepage(JOURNAL), 8),
     ]
     #+JOURNAL_LISTINGS
     #+JOURNAL_LISTINGS_OF_LISTINGS

--- a/spectrum/load.py
+++ b/spectrum/load.py
@@ -71,14 +71,15 @@ class AllOf():
         action.run()
 
 JOURNAL_LISTINGS = [
-    (JournalListing(checks.JOURNAL, '/subjects/neuroscience'), 2)
+    (JournalListing(checks.JOURNAL, p), 2) for p in checks.JOURNAL_LISTING_PATHS
 ]
 JOURNAL_PAGES = [
-    (JournalPage(checks.JOURNAL, '/about'), 1)
+    (JournalPage(checks.JOURNAL, p), 1)
+    for p in checks.JOURNAL_GENERIC_PATHS
 ]
 JOURNAL_ALL = AllOf(
     [
-        (JournalSearch(checks.JOURNAL), 4)
+        (JournalSearch(checks.JOURNAL), 8)
     ]
     +JOURNAL_LISTINGS
     +JOURNAL_PAGES

--- a/spectrum/load.py
+++ b/spectrum/load.py
@@ -14,15 +14,17 @@ class JournalSearch():
 class JournalListing():
     def __init__(self, journal, path):
         self._journal = journal
-        self._path = path
+        self._queue = [path]
 
     def run(self):
-        LOGGER.info("Loading %s", self._path)
-        items = self._journal.listing(self._path)
+        path = self._queue.pop()
+        LOGGER.info("Loading listing %s", path)
+        items, links = self._journal.listing(path)
         for item in items:
             LOGGER.info("Loading %s", item)
             self._journal.generic(item)
-        # TODO: next page
+        for link in links:
+            self._queue.insert(0, link)
 
 class AllOf():
     def __init__(self, actions):

--- a/spectrum/load.py
+++ b/spectrum/load.py
@@ -57,6 +57,7 @@ class JournalListing():
                 self._items.enqueue(item)
             for link in links:
                 self._pages.enqueue(link)
+        # TODO: really necessary?
         self._pages.restart_if_empty()
 
     def __str__(self):
@@ -96,16 +97,21 @@ class JournalPage():
 class JournalHomepage():
     def __init__(self, journal):
         self._journal = journal
+        self._links = Queue()
 
     def run(self):
-        LOGGER.info("Loading homepage /")
-        links = self._journal.homepage()
-        for link in links:
+        if len(self._links):
+            link = self._links.dequeue()
             LOGGER.info("Loading link %s", link)
             self._journal.generic(link)
+        else:
+            LOGGER.info("Loading homepage /")
+            links = self._journal.homepage()
+            for link in links:
+                self._links.enqueue(link)
 
     def __str__(self):
-        return "JournalHomepage()"
+        return "JournalHomepage(links queue length %s)" % len(self._links)
 
 class AllOf():
     def __init__(self, actions):
@@ -144,9 +150,9 @@ JOURNAL_PAGES = [
 JOURNAL_ALL = AllOf(
     [
         #(JournalSearch(JOURNAL), 8),
-        #(JournalHomepage(JOURNAL), 8),
+        (JournalHomepage(JOURNAL), 8),
     ]
     #+JOURNAL_LISTINGS
-    +JOURNAL_LISTINGS_OF_LISTINGS
+    #+JOURNAL_LISTINGS_OF_LISTINGS
     #+JOURNAL_PAGES
 )

--- a/spectrum/load.py
+++ b/spectrum/load.py
@@ -77,7 +77,19 @@ class JournalPage():
     def __str__(self):
         return "JournalPage(%s)" % self._path
 
-# TODO: JournalHomepage
+class JournalHomepage():
+    def __init__(self, journal):
+        self._journal = journal
+
+    def run(self):
+        LOGGER.info("Loading homepage /")
+        links = self._journal.homepage()
+        for link in links:
+            LOGGER.info("Loading link %s", link)
+            self._journal.generic(link)
+
+    def __str__(self):
+        return "JournalHomepage()"
 
 class AllOf():
     def __init__(self, actions):
@@ -115,7 +127,8 @@ JOURNAL_PAGES = [
 ]
 JOURNAL_ALL = AllOf(
     [
-        (JournalSearch(JOURNAL), 8)
+        (JournalSearch(JOURNAL), 8),
+        (JournalHomepage(JOURNAL), 800),
     ]
     +JOURNAL_LISTINGS
     +JOURNAL_LISTINGS_OF_LISTINGS

--- a/spectrum/load.py
+++ b/spectrum/load.py
@@ -1,3 +1,4 @@
+import string
 from random import randint
 from spectrum import logger, input, checks
 
@@ -25,9 +26,10 @@ class Queue():
         return len(self._contents)
 
 class JournalSearch():
-    def __init__(self, journal, length=3):
+    def __init__(self, journal, length=3, characters=string.ascii_lowercase):
         self._journal = journal
         self._length = length
+        self._characters = characters
         self._results = Queue()
 
     def run(self):
@@ -36,7 +38,7 @@ class JournalSearch():
             LOGGER.info("Loading search result %s", result)
             self._journal.generic(result)
         else:
-            word = input.invented_word(self._length)
+            word = input.invented_word(self._length, self._characters)
             LOGGER.info("Searching for %s", word)
             results = self._journal.search(word, count=None)
             # TODO: Queue.enqueue_all

--- a/spectrum/load.py
+++ b/spectrum/load.py
@@ -102,19 +102,20 @@ class AllOf():
         LOGGER.info("Selecting action %s", action)
         action.run()
 
+JOURNAL = checks.JOURNAL.with_resource_checking_method('get')
 JOURNAL_LISTINGS = [
-    (JournalListing(checks.JOURNAL, p), 2) for p in checks.JOURNAL_LISTING_PATHS
+    (JournalListing(JOURNAL, p), 2) for p in checks.JOURNAL_LISTING_PATHS
 ]
 JOURNAL_LISTINGS_OF_LISTINGS = [
-    (JournalListingOfListing(checks.JOURNAL, p), 200) for p in checks.JOURNAL_LISTING_OF_LISTING_PATHS
+    (JournalListingOfListing(JOURNAL, p), 200) for p in checks.JOURNAL_LISTING_OF_LISTING_PATHS
 ]
 JOURNAL_PAGES = [
-    (JournalPage(checks.JOURNAL, p), 1)
+    (JournalPage(JOURNAL, p), 1)
     for p in checks.JOURNAL_GENERIC_PATHS
 ]
 JOURNAL_ALL = AllOf(
     [
-        (JournalSearch(checks.JOURNAL), 8)
+        (JournalSearch(JOURNAL), 8)
     ]
     +JOURNAL_LISTINGS
     +JOURNAL_LISTINGS_OF_LISTINGS

--- a/spectrum/load.py
+++ b/spectrum/load.py
@@ -4,17 +4,22 @@ from spectrum import logger, input, checks
 LOGGER = logger.logger(__name__)
 
 class JournalSearch():
-    def __init__(self, journal):
+    def __init__(self, journal, length=3):
         self._journal = journal
+        self._length = length
 
     def run(self):
-        word = input.invented_word(3)
+        word = input.invented_word(self._length)
         LOGGER.info("Searching for %s", word)
         self._journal.search(word, count=None)
+
+    def __str__(self):
+        return "JournalSearch(length=%s)" % self._length
 
 class JournalListing():
     def __init__(self, journal, path):
         self._journal = journal
+        self._path = path
         self._queue = [path]
 
     def run(self):
@@ -27,6 +32,9 @@ class JournalListing():
         for link in links:
             self._queue.insert(0, link)
 
+    def __str__(self):
+        return "JournalListing(%s, queue length %s)" % self._path, len(self._queue)
+
 class JournalPage():
     def __init__(self, journal, path):
         self._journal = journal
@@ -35,6 +43,9 @@ class JournalPage():
     def run(self):
         LOGGER.info("Loading fixed page %s", self._path)
         self._journal.generic(self._path)
+
+    def __str__(self):
+        return "JournalPage(%s)" % self._path
 
 # TODO: JournalHomepage
 

--- a/spectrum/load.py
+++ b/spectrum/load.py
@@ -1,0 +1,30 @@
+from spectrum import logger, input, checks
+
+LOGGER = logger.logger(__name__)
+
+class JournalSearch():
+    def __init__(self, journal):
+        self._journal = journal
+
+    def run(self):
+        word = input.invented_word(3)
+        LOGGER.info("Searching for %s", word)
+        self._journal.search(word, count=None)
+
+class JournalListing():
+    def __init__(self, journal, path):
+        self._journal = journal
+        self._path = path
+
+    def run(self)
+        LOGGER.info("Loading %s", self._path)
+        items = self._journal.listing(self._path)
+        for i in items:
+            self._journal.generic(i)
+        # TODO: next page
+
+        
+JOURNAL_SEARCH = JournalSearch(checks.JOURNAL)
+JOURNAL_LISTINGS = [
+    JournalListing(checks.JOURNAL, '/subjects/neuroscience')
+]

--- a/spectrum/load.py
+++ b/spectrum/load.py
@@ -26,6 +26,17 @@ class JournalListing():
         for link in links:
             self._queue.insert(0, link)
 
+class JournalPage():
+    def __init__(self, journal, path):
+        self._journal = journal
+        self._path = path
+
+    def run(self):
+        LOGGER.info("Loading fixed page %s", self._path)
+        self._journal.generic(self._path)
+
+# TODO: JournalHomepage
+
 class AllOf():
     def __init__(self, actions):
         self._actions = actions
@@ -39,4 +50,7 @@ JOURNAL_SEARCH = JournalSearch(checks.JOURNAL)
 JOURNAL_LISTINGS = [
     JournalListing(checks.JOURNAL, '/subjects/neuroscience')
 ]
-JOURNAL_ALL = AllOf([JOURNAL_SEARCH]+JOURNAL_LISTINGS)
+JOURNAL_PAGES = [
+    JournalPage(checks.JOURNAL, '/about')
+]
+JOURNAL_ALL = AllOf([JOURNAL_SEARCH]+JOURNAL_LISTINGS+[JOURNAL_PAGES])

--- a/spectrum/load.py
+++ b/spectrum/load.py
@@ -18,6 +18,10 @@ class Queue():
         LOGGER.debug("Enqueuing %s", path_to_visit)
         self._contents.insert(0, path_to_visit)
 
+    def enqueue_all(self, paths):
+        for path in paths:
+            self.enqueue(path)
+
     def restart_if_empty(self):
         if len(self._contents) == 0:
             LOGGER.warning("Need to refill queue with %s", self._seed)
@@ -42,9 +46,7 @@ class JournalSearch():
             word = input.invented_word(self._length, self._characters)
             LOGGER.info("Searching for %s", word)
             results = self._journal.search(word, count=None)
-            # TODO: Queue.enqueue_all
-            for result in results:
-                self._results.enqueue(result)
+            self._results.enqueue_all(results)
 
     def __str__(self):
         return "JournalSearch(length=%s)" % self._length
@@ -65,10 +67,8 @@ class JournalListing():
             path = self._pages.dequeue()
             LOGGER.info("Loading listing page %s", path)
             items, links = self._journal.listing(path)
-            for item in items:
-                self._items.enqueue(item)
-            for link in links:
-                self._pages.enqueue(link)
+            self._items.enqueue_all(items)
+            self._pages.enqueue_all(links)
         self._pages.restart_if_empty()
 
     def __str__(self):
@@ -118,8 +118,7 @@ class JournalHomepage():
         else:
             LOGGER.info("Loading homepage /")
             links = self._journal.homepage()
-            for link in links:
-                self._links.enqueue(link)
+            self._links.enqueue_all(links)
 
     def __str__(self):
         return "JournalHomepage(links queue length %s)" % len(self._links)

--- a/spectrum/logger.py
+++ b/spectrum/logger.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 class OptionalArticleIdFilter(logging.Filter):
     def filter(self, record):
@@ -27,3 +28,9 @@ def logger(name):
 def set_logging_level(level):
     "e.g. logging.INFO"
     logging.getLogger().setLevel(level)
+
+# pytest does not allow to read a cli argument globally, but
+# only from a test or a fixture afaik
+# so, workaround "trying hard to be an extensible tool and failing at it"
+LOG_LEVEL = os.environ.get('SPECTRUM_LOG_LEVEL', 'INFO')
+set_logging_level(getattr(logging, LOG_LEVEL))

--- a/spectrum/test_journal.py
+++ b/spectrum/test_journal.py
@@ -31,6 +31,14 @@ def test_listings(path):
 
 @pytest.mark.two
 @pytest.mark.journal_cms
+@pytest.mark.parametrize("path", checks.JOURNAL_LISTING_OF_LISTING_PATHS)
+def test_listings_of_listings(path):
+    items = checks.JOURNAL.listing_of_listing(path)
+    if len(items):
+        checks.JOURNAL.generic(items[0])
+
+@pytest.mark.two
+@pytest.mark.journal_cms
 def test_events():
     items, _ = checks.JOURNAL.listing('/events')
     if len(items):

--- a/spectrum/test_journal.py
+++ b/spectrum/test_journal.py
@@ -6,7 +6,9 @@ from spectrum import checks
 @pytest.mark.journal_cms
 @pytest.mark.search
 def test_homepage():
-    checks.JOURNAL.homepage()
+    links = checks.JOURNAL.homepage()
+    if len(links):
+        checks.JOURNAL.generic(links[0])
 
 @pytest.mark.two
 @pytest.mark.journal_cms

--- a/spectrum/test_journal.py
+++ b/spectrum/test_journal.py
@@ -52,14 +52,14 @@ def test_various_generic_pages(path):
 @pytest.mark.journal_cms
 @pytest.mark.parametrize("path", LISTING_PATHS)
 def test_listings(path):
-    items, links = checks.JOURNAL.listing(path)
+    items, _ = checks.JOURNAL.listing(path)
     if len(items):
         checks.JOURNAL.generic(items[0])
 
 @pytest.mark.two
 @pytest.mark.journal_cms
 def test_events():
-    items, links = checks.JOURNAL.listing('/events')
+    items, _ = checks.JOURNAL.listing('/events')
     if len(items):
         checks.JOURNAL.generic(items[0])
 

--- a/spectrum/test_journal.py
+++ b/spectrum/test_journal.py
@@ -52,14 +52,14 @@ def test_various_generic_pages(path):
 @pytest.mark.journal_cms
 @pytest.mark.parametrize("path", LISTING_PATHS)
 def test_listings(path):
-    items = checks.JOURNAL.listing(path)
+    items, links = checks.JOURNAL.listing(path)
     if len(items):
         checks.JOURNAL.generic(items[0])
 
 @pytest.mark.two
 @pytest.mark.journal_cms
 def test_events():
-    items = checks.JOURNAL.listing('/events')
+    items, links = checks.JOURNAL.listing('/events')
     if len(items):
         checks.JOURNAL.generic(items[0])
 

--- a/spectrum/test_journal.py
+++ b/spectrum/test_journal.py
@@ -2,32 +2,6 @@
 import pytest
 from spectrum import checks
 
-GENERIC_PATHS = [
-    "/about",
-    "/about/early-career",
-    "/about/innovation",
-    "/about/openness",
-    "/about/peer-review",
-    "/alerts",
-    "/annual-reports",
-    "/archive/2016",
-    "/community",
-    "/contact",
-    "/for-the-press",
-    "/resources",
-    "/terms",
-    #/who-we-work-with
-]
-
-LISTING_PATHS = [
-    '/articles/correction',
-    '/collections',
-    '/inside-elife',
-    '/labs',
-    '/podcast',
-    '/subjects',
-]
-
 @pytest.mark.two
 @pytest.mark.journal_cms
 @pytest.mark.search
@@ -43,14 +17,14 @@ def test_magazine():
 
 @pytest.mark.two
 @pytest.mark.journal_cms
-@pytest.mark.parametrize("path", GENERIC_PATHS)
+@pytest.mark.parametrize("path", checks.JOURNAL_GENERIC_PATHS)
 def test_various_generic_pages(path):
     checks.JOURNAL.generic(path)
 
 
 @pytest.mark.two
 @pytest.mark.journal_cms
-@pytest.mark.parametrize("path", LISTING_PATHS)
+@pytest.mark.parametrize("path", checks.JOURNAL_LISTING_PATHS)
 def test_listings(path):
     items, _ = checks.JOURNAL.listing(path)
     if len(items):

--- a/spectrum/test_journal.py
+++ b/spectrum/test_journal.py
@@ -21,7 +21,6 @@ def test_magazine():
 def test_various_generic_pages(path):
     checks.JOURNAL.generic(path)
 
-
 @pytest.mark.two
 @pytest.mark.journal_cms
 @pytest.mark.parametrize("path", checks.JOURNAL_LISTING_PATHS)


### PR DESCRIPTION
Single process, which can be executed in multiple copies.

Chooses between three kind of loads to create:
- loading a static page
- going through a listing's item and pages
- searching for a random string

When a page is visited, all resources like scripts, CSS and images are accessed (through HEAD requests at the moment).

To be expanded with other pages or workflows we are interested in for stress testing.