### PR TITLE
Robustness in kitchen sink update

### DIFF
--- a/checkout.sh
+++ b/checkout.sh
@@ -10,5 +10,6 @@ revision=${1:-master}
 
 git fetch
 git checkout ${revision}
+git reset --hard
 git lfs pull
 ./install.sh

--- a/import-xml.sh
+++ b/import-xml.sh
@@ -9,5 +9,6 @@ fi
 
 id="$1"
 source_filename="$2"
+set -o pipefail
 xmllint -format "$source_filename" | sed -e "s/$id/{{ article['id'] }}/g" > "spectrum/templates/elife-$id-vor-r1/elife-$id.xml.jinja"
 


### PR DESCRIPTION
- Error in xmllint should propagate up and make the update build fail
- Local modifications should be overwritten when checking out master or any branch
We had a kitchen sink that wasn't valid in https://ci--alfred.elifesciences.org/job/dependencies-elife-spectrum-update-kitchen-sinks-github/36/console, then it remained there and was passed to the bot as an empty file.