### PR TITLE
Checking propagation of article image update to search

### DIFF
--- a/spectrum/input.py
+++ b/spectrum/input.py
@@ -156,6 +156,7 @@ class JournalCmsSession:
         response = self._browser.submit(form, edit_page.url, data={'op': button_text})
         view_page = self._browser.get(view_url)
         img = view_page.soup.select_one(".field--name-field-image img")
+        assert img, ("Cannot find `.field--name-field-image img` in %s" % view_url)
         assert "king_county" in img.get('src')
         LOGGER.info(
             "Tag: %s",


### PR DESCRIPTION
Or to any backend, for that matter. The test uses an invented, unique word to
reliably find one item in the search API:
```
[2017-05-22 15:02:18,948][INFO][spectrum.checks][4348358295504415893]
Found article version 1 on api:
https://end2end--gateway.elifesciences.org/articles/4348358295504415893
[2017-05-22 15:02:19,862][INFO][spectrum.checks][] Found
https://end2end--cdn-iiif.elifesciences.org/journal-cms:article/2017-05/king_county_158.jpg/full/full/0/default.jpg:
200
[2017-05-22 15:02:20,687][INFO][spectrum.checks][]
https://end2end--gateway.elifesciences.org/search?for=g5odqr1seqg5spobyml4jeouzn0aay:
returning 1 results and satisfying check
SearchItemCheckImage(https://end2end--cdn-iiif.elifesciences.org/journal-cms:article/2017-05/king_county_158.jpg/full/full/0/default.jpg)
```