### PR TITLE
Checking an image field appears in the API first

### DIFF
--- a/spectrum/input.py
+++ b/spectrum/input.py
@@ -157,7 +157,7 @@ class JournalCmsSession:
         view_page = self._browser.get(view_url)
         img_selector = ".field--name-field-image img"
         img = view_page.soup.select_one(img_selector)
-        assert img is not None, ("Cannot find %s in %s response\n%s" % img_selector, view_page.status_code, view_page.content)
+        assert img is not None, ("Cannot find %s in %s response\n%s" % (img_selector, view_page.status_code, view_page.content))
         assert "king_county" in img.get('src')
         LOGGER.info(
             "Tag: %s",

--- a/spectrum/test_article.py
+++ b/spectrum/test_article.py
@@ -142,13 +142,12 @@ def test_adding_article_fragment(generate_article, modify_article):
     _ingest_and_publish_and_wait_for_published(article)
 
     journal_cms_session.create_article_fragment(id=article.id(), image='./spectrum/fixtures/king_county.jpg')
-    article = checks.API.article(article.id())
-    # TODO: transition to IIIF and use a IiifCheck object
+    article = checks.API.wait_article(article.id(), item_check=checks.API.item_check_image())
     image_uri = article['image']['thumbnail']['source']['uri']
     response = requests.head(image_uri)
     checks.LOGGER.info("Found %s: %s", image_uri, response.status_code)
     assert response.status_code == 200, "Image %s is not loading" % image_uri
-    checks.API.wait_search(invented_word, item_check=checks.API.search_item_check_image(image_uri))
+    checks.API.wait_search(invented_word, item_check=checks.API.item_check_image(image_uri))
 
 def _ingest(article):
     input.PRODUCTION_BUCKET.upload(article.filename(), article.id())


### PR DESCRIPTION
Solves some instabilities such as https://ci--alfred.elifesciences.org/job/test-journal/886/console

After adding the article fragment, better to wait for an image field to
appear in the article on the API. Then we can check its propagation to
search and even check its URI, since we now have that value. No easy way to
predict the URL from journal-cms