### PR TITLE
Retry on 504 on page resource

### DIFF
--- a/spectrum/checks.py
+++ b/spectrum/checks.py
@@ -813,6 +813,11 @@ def _assert_all_load(resources, host, resource_checking_method='head', **extra):
     for url, future in zip(urls, futures):
         response = future.result()
         LOGGER.debug("Loading (%s) resource %s", resource_checking_method, url, extra=extra)
+
+        if response.status_code == 504:
+            LOGGER.warning("Loading (%s) resource %s again due to 504 timeout", resource_checking_method, url, extra=extra)
+            response = requests.get(url)
+
         _assert_status_code(response, 200, url)
         RESOURCE_CACHE[url] = response.status_code
 


### PR DESCRIPTION
We load many resources in parallel taken from the page HTML code. However if we get a 504 from CloudFront we can retry rather than failing.

The retry is not parallel, it's supposed to happen rarely