### PR TITLE
Test personalised covers

### DIFF
--- a/spectrum/checks.py
+++ b/spectrum/checks.py
@@ -46,6 +46,11 @@ class UnrecoverableError(RuntimeError):
 
 class BucketFileCheck:
     def __init__(self, s3, bucket_name, key, prefix=None):
+        """Polls for the existence of a file in bucket_name.
+
+        key is a pattern to be filled with the args passed to of().
+        prefix is a API call filter to be used to reduce the number of objects to scan.
+        """
         self._s3 = s3
         self._bucket_name = bucket_name
         self._key = key
@@ -836,10 +841,22 @@ EIF = BucketFileCheck(
 ARCHIVE = BucketFileCheck(
     aws.S3,
     SETTINGS['bucket_archive'],
-    # notice {{6}} is the escaping for {6} in the regex,
+    # notice {{12}} is the escaping for {6} in the regex,
     # it should not be substituted
     'elife-{id}-(poa|vor)-v{version}-20[0-9]{{12}}.zip',
     'elife-{id}-'
+)
+PERSONALISED_COVERS_A4 = BucketFileCheck(
+    aws.S3,
+    SETTINGS['bucket_covers'],
+    '{id}-cover-a4.pdf',
+    '{id}-'
+)
+PERSONALISED_COVERS_LETTER = BucketFileCheck(
+    aws.S3,
+    SETTINGS['bucket_covers'],
+    '{id}-cover-letter.pdf',
+    '{id}-'
 )
 WEBSITE = WebsiteArticleCheck(
     host=SETTINGS['website_host'],

--- a/spectrum/test_article.py
+++ b/spectrum/test_article.py
@@ -149,6 +149,13 @@ def test_adding_article_fragment(generate_article, modify_article):
     assert response.status_code == 200, "Image %s is not loading" % image_uri
     checks.API.wait_search(invented_word, item_check=checks.API.item_check_image(image_uri))
 
+@pytest.mark.personalised_covers
+def test_personalised_covers_for_new_articles(generate_article):
+    article = generate_article(15893)
+    _ingest_and_publish_and_wait_for_published(article)
+    checks.PERSONALISED_COVERS_A4.of(id=article.id())
+    checks.PERSONALISED_COVERS_LETTER.of(id=article.id())
+
 def _ingest(article):
     input.PRODUCTION_BUCKET.upload(article.filename(), article.id())
 


### PR DESCRIPTION
After an article has been published, we should have two personalised covers available and publicly accessible in the related bucket. We can predict their name and poll for their existence.