### PR TITLE
Connecting journal and profiles

### DIFF
--- a/spectrum/input.py
+++ b/spectrum/input.py
@@ -102,7 +102,7 @@ class JournalCmsSession:
         # not sure why, but `data` here is necessary
         response = self._browser.submit(form, create_page.url, data={'op': 'Save and publish'})
         # requests follows redirects by default
-        self._assert_html_response(response)
+        _assert_html_response(response)
         assert _journal_cms_page_title(response.soup) == title
         #check https://end2end--journal-cms.elifesciences.org/admin/content?status=All&type=All&title=b9djvu04y6v1t4kug4ts8kct5pagf8&langcode=All
         # but in checks module
@@ -152,7 +152,7 @@ class JournalCmsSession:
         button_text = edit_page.soup.find('div', {'id': 'edit-actions'}).find('input', 'form-submit').get('value')
         response = self._browser.submit(form, edit_page.url, data={'op': button_text})
         # requests follows redirects by default
-        self._assert_html_response(response)
+        _assert_html_response(response)
         view_page = self._browser.get(view_url)
         img_selector = ".field--name-field-image img"
         img = view_page.soup.select_one(img_selector)
@@ -183,13 +183,58 @@ class JournalCmsSession:
                 continue
             del inp['name']
 
-    def _assert_html_response(self, response):
-        assert response.status_code == 200, "Response from saving the from was expected to be 200 from the listing page, but it was %s\nBody: %s" % (response.status_code, response.content)
+def _assert_html_response(response):
+    assert response.status_code == 200, "Response from saving the from was expected to be 200 from the listing page, but it was %s\nBody: %s" % (response.status_code, response.content)
 
 def _journal_cms_page_title(soup):
     # <h1 class="js-quickedit-page-title title page-title"><span data-quickedit-field-id="node/1709/title/en/full" class="field field--name-title field--type-string field--label-hidden">Spectrum blog article: jvsfz4oj9vz9hk239fbpq4fbjc9yoh</span></h1>
     #<h1 class="js-quickedit-page-title title page-title">alfred</h1>
     return soup.find("h1", {"class": "page-title"}).text.strip()
+
+class Journal:
+    def __init__(self, host):
+        self._host = host
+
+    def session(self):
+        browser = mechanicalsoup.Browser()
+        return JournalSession(self._host, browser)
+
+class JournalSession:
+    def __init__(self, host, browser):
+        self._host = host
+        self._browser = browser
+
+    def login(self):
+        feature_flag = "%s/?open-sesame" % self._host
+        flagged_page = self._browser.get(feature_flag)
+        _assert_html_response(flagged_page)
+        login_url = "%s/log-in" % self._host
+        # should be automatically redirected back by simulator
+        logged_in_page = self._browser.get(login_url)
+        # <a href="/log-out" class="button button--extra-small button--default">Log out</a>
+        print logged_in_page.content
+        _assert_html_response(logged_in_page)
+        print logged_in_page.soup
+        #form = mechanicalsoup.Form(create_page.soup.form)
+        #form.input({'title[0][value]': title})
+        #LOGGER.info("Adding paragraph")
+        #self._choose_submit(form, 'field_content_paragraph_add_more')
+        #response = self._browser.submit(form, create_page.url)
+        #form = mechanicalsoup.Form(response.soup.form)
+        #form.textarea({'field_content[0][subform][field_block_html][0][value]': text})
+        #if image:
+        #    form.attach({'files[field_image_0]': image})
+        #    LOGGER.info("Attaching image")
+
+        #LOGGER.info("Saving form")
+        #self._choose_submit(form, 'op', value='Save and publish')
+        ## not sure why, but `data` here is necessary
+        #response = self._browser.submit(form, create_page.url, data={'op': 'Save and publish'})
+        ## requests follows redirects by default
+        #assert _journal_cms_page_title(response.soup) == title
+        ##check https://end2end--journal-cms.elifesciences.org/admin/content?status=All&type=All&title=b9djvu04y6v1t4kug4ts8kct5pagf8&langcode=All
+        ## but in checks module
+        ## TODO: return id and/or node id
 
 def invented_word(length=30, characters=None):
     if not characters:
@@ -217,4 +262,8 @@ JOURNAL_CMS = JournalCms(
     SETTINGS['journal_cms_host'],
     SETTINGS['journal_cms_user'],
     SETTINGS['journal_cms_password']
+)
+
+JOURNAL = Journal(
+    SETTINGS['journal_host'],
 )

--- a/spectrum/input.py
+++ b/spectrum/input.py
@@ -1,5 +1,6 @@
 from os import path
 import random
+import re
 import string
 import requests
 from spectrum import aws, logger
@@ -205,36 +206,22 @@ class JournalSession:
         self._browser = browser
 
     def login(self):
-        feature_flag = "%s/?open-sesame" % self._host
-        flagged_page = self._browser.get(feature_flag)
-        _assert_html_response(flagged_page)
+        self._enable_feature_flag()
+
         login_url = "%s/log-in" % self._host
         # should be automatically redirected back by simulator
         logged_in_page = self._browser.get(login_url)
-        # <a href="/log-out" class="button button--extra-small button--default">Log out</a>
-        print logged_in_page.content
         _assert_html_response(logged_in_page)
-        print logged_in_page.soup
-        #form = mechanicalsoup.Form(create_page.soup.form)
-        #form.input({'title[0][value]': title})
-        #LOGGER.info("Adding paragraph")
-        #self._choose_submit(form, 'field_content_paragraph_add_more')
-        #response = self._browser.submit(form, create_page.url)
-        #form = mechanicalsoup.Form(response.soup.form)
-        #form.textarea({'field_content[0][subform][field_block_html][0][value]': text})
-        #if image:
-        #    form.attach({'files[field_image_0]': image})
-        #    LOGGER.info("Attaching image")
 
-        #LOGGER.info("Saving form")
-        #self._choose_submit(form, 'op', value='Save and publish')
-        ## not sure why, but `data` here is necessary
-        #response = self._browser.submit(form, create_page.url, data={'op': 'Save and publish'})
-        ## requests follows redirects by default
-        #assert _journal_cms_page_title(response.soup) == title
-        ##check https://end2end--journal-cms.elifesciences.org/admin/content?status=All&type=All&title=b9djvu04y6v1t4kug4ts8kct5pagf8&langcode=All
-        ## but in checks module
-        ## TODO: return id and/or node id
+        pattern = re.compile(r'Log out')
+        logout_link = logged_in_page.soup.find("a", text=pattern)
+        assert logout_link.get('href'), '/log-out'
+
+    def _enable_feature_flag(self):
+        feature_flag = "%s/?open-sesame" % self._host
+        flagged_page = self._browser.get(feature_flag)
+        _assert_html_response(flagged_page)
+
 
 def invented_word(length=30, characters=None):
     if not characters:

--- a/spectrum/input.py
+++ b/spectrum/input.py
@@ -222,7 +222,6 @@ class JournalSession:
         flagged_page = self._browser.get(feature_flag)
         _assert_html_response(flagged_page)
 
-
 def invented_word(length=30, characters=None):
     if not characters:
         characters = string.ascii_lowercase + string.digits

--- a/spectrum/test_journal.py
+++ b/spectrum/test_journal.py
@@ -1,6 +1,6 @@
 "Tests that involve Journal pages that are not covered by other tests"
 import pytest
-from spectrum import checks
+from spectrum import checks, input
 
 @pytest.mark.two
 @pytest.mark.journal_cms
@@ -53,6 +53,14 @@ def test_rss_feeds():
     print recent_response.content
     ahead_response = checks.JOURNAL.just_load('/rss/ahead.xml')
     print ahead_response.content
+
+# TODO: mark with `journal` all `two` to better isolate them
+@pytest.mark.journal
+@pytest.mark.profiles
+def test_login():
+    session = input.JOURNAL.session()
+    session.login()
+
 
 #path: /interviews/{id}
 # how do we get the link? navigate from /collections

--- a/spectrum/test_journal.py
+++ b/spectrum/test_journal.py
@@ -61,7 +61,6 @@ def test_login():
     session = input.JOURNAL.session()
     session.login()
 
-
 #path: /interviews/{id}
 # how do we get the link? navigate from /collections
 


### PR DESCRIPTION
Journal tries to log in, uses profiles and the orcid-dummy to do so. We don't have control on what happens on the ORCID side, so orcid-dummy sends back the user with a successful authentication without any further user interaction.

The only check we can make on the logged in page so far is on the `Log out` button. We don't log out as it's not an integrated feature (so far), that can be tested purely in journal.