### PR TITLE
Basic end2end tests involving /profiles

### DIFF
--- a/spectrum/checks.py
+++ b/spectrum/checks.py
@@ -406,7 +406,10 @@ class ApiCheck:
         self._list_api('/collections', 'collection')
 
     def profiles(self):
-        self._list_api('/profiles', 'profile')
+        return self._list_api('/profiles', 'profile')
+
+    def profile(self, id):
+        return self._item_api('/profiles/%s' % id, 'profile')
 
     def _list_api(self, path, entity):
         url = "%s%s" % (self._host, path)

--- a/spectrum/checks.py
+++ b/spectrum/checks.py
@@ -405,6 +405,9 @@ class ApiCheck:
     def collections(self):
         self._list_api('/collections', 'collection')
 
+    def profiles(self):
+        self._list_api('/profiles', 'profile')
+
     def _list_api(self, path, entity):
         url = "%s%s" % (self._host, path)
         response = requests.get(url, headers=self._base_headers({'Accept': 'application/vnd.elife.%s-list+json; version=1' % entity}))

--- a/spectrum/test_api.py
+++ b/spectrum/test_api.py
@@ -18,6 +18,10 @@ def test_list_based_apis_journal_cms():
 def test_list_based_apis_medium():
     checks.API.medium_articles()
 
+@pytest.mark.profiles
+def test_list_based_apis_profiles():
+    checks.API.profiles()
+
 @pytest.mark.two
 @pytest.mark.search
 def test_search():

--- a/spectrum/test_journal.py
+++ b/spectrum/test_journal.py
@@ -66,6 +66,19 @@ def test_rss_feeds():
 def test_login():
     session = input.JOURNAL.session()
     session.login()
+    # no pagination needed so far
+    profiles = checks.API.profiles()['items']
+    id = None
+    magic_orcid = '0000-0002-1825-0097'
+    for profile_snippet in profiles:
+        # magic ORCID used by orcid-dummy
+        if profile_snippet['orcid'] == magic_orcid:
+            id = profile_snippet['id']
+    assert id is not None, "We didn't find the profile for the test user in %s" % profiles
+    profile = checks.API.profile(id)
+    assert profile['id'] == id
+    assert profile['orcid'] == magic_orcid
+    assert profile['name'] == {'index': 'Carberry, Josiah', 'preferred': 'Josiah Carberry'}
     session.logout()
 
 #path: /interviews/{id}


### PR DESCRIPTION
Very rough at this time.

- Load /profiles as a sanity check
- Adding check on profile sanity after login