### PR TITLE
ELPP-3366 Check a public profile page

### DIFF
--- a/spectrum/input.py
+++ b/spectrum/input.py
@@ -222,7 +222,7 @@ class JournalSession:
         self._browser = browser
 
     def login(self):
-        self._enable_feature_flag()
+        self.enable_feature_flag()
 
         login_url = "%s/log-in" % self._host
         # should be automatically redirected back by simulator
@@ -251,7 +251,7 @@ class JournalSession:
 
         return page
 
-    def _enable_feature_flag(self):
+    def enable_feature_flag(self):
         feature_flag = "%s/?open-sesame" % self._host
         flagged_page = self._browser.get(feature_flag)
         _assert_html_response(flagged_page)

--- a/spectrum/test_journal.py
+++ b/spectrum/test_journal.py
@@ -71,7 +71,8 @@ def test_logging_in_and_out():
 
 @pytest.mark.journal
 @pytest.mark.profiles
-def test_profile():
+@pytest.mark.annotations
+def test_logged_in_profile():
     session = input.JOURNAL.session()
     session.login()
 
@@ -86,6 +87,16 @@ def test_profile():
     assert id is not None, "We didn't find the profile for the test user in %s" % profiles
 
     session.check('/profiles/%s' % id)
+
+@pytest.mark.journal
+@pytest.mark.profiles
+@pytest.mark.annotations
+def test_public_profile():
+    session = input.JOURNAL.session()
+    session.enable_feature_flag()
+
+    magic_profile_id = 'pb74izre'
+    session.check('/profiles/%s' % magic_profile_id)
 
 #path: /interviews/{id}
 # how do we get the link? navigate from /collections


### PR DESCRIPTION
Turns out the existing test already loads the logged in user's own profile page.

The test being added loads the same page from the point of view of an anonymous user, considering its public version which may differ and feature less content.

The anonymous user still enables its feature flag.