### PR TITLE
Filter with run_after using greater than or equal

### DIFF
--- a/spectrum/checks.py
+++ b/spectrum/checks.py
@@ -217,7 +217,7 @@ class DashboardArticleCheck:
         return matching_runs[0]
 
     def _check_for_run_after(self, version_contents, run_after):
-        matching_runs = [r for _, r in version_contents['runs'].iteritems() if datetime.fromtimestamp(r['first-event-timestamp']).strftime('%s') > run_after.strftime('%s')]
+        matching_runs = [r for _, r in version_contents['runs'].iteritems() if datetime.fromtimestamp(r['first-event-timestamp']).strftime('%s') >= run_after.strftime('%s')]
         if len(matching_runs) > 1:
             raise RuntimeError("Too many runs after run_after %s: %s", run_after, matching_runs)
         if len(matching_runs) == 0:


### PR DESCRIPTION
The dashboard API only returns a timestamp in seconds, so we cannot strictly compare with a microsecond timestamp generated by the tests. Ensure both are seconds and compare with `>=`.