### PR TITLE
Full log in and log out scenario

### DIFF
--- a/spectrum/input.py
+++ b/spectrum/input.py
@@ -227,6 +227,7 @@ class JournalSession:
         headers = {}
         if referer:
             headers['Referer'] = '%s%s' % (self._host, referer)
+        LOGGER.info("Logging in at %s (headers %s)", login_url, headers)
         logged_in_page = self._browser.get(login_url, headers=headers)
         # should be automatically redirected back by simulator
         _assert_html_response(logged_in_page)
@@ -235,6 +236,7 @@ class JournalSession:
         profile_selector = ".login-control__non_js_control_link"
         profile = logged_in_page.soup.select_one(profile_selector)
         assert profile is not None, ("Cannot find %s in %s response\n%s" % (profile_selector, logged_in_page.status_code, logged_in_page.content))
+        LOGGER.info("Found logged-in profile button at %s", profile_selector)
 
         return logged_in_page
 

--- a/spectrum/input.py
+++ b/spectrum/input.py
@@ -232,6 +232,7 @@ class JournalSession:
         LOGGER.info("Logging in at %s (headers %s)", login_url, headers)
         logged_in_page = self._browser.get(login_url, headers=headers)
         # should be automatically redirected back by simulator
+        LOGGER.info("Redirected to %s after log in", logged_in_page.url)
         _assert_html_response(logged_in_page)
 
         # if changing to another check, move in logout()
@@ -244,15 +245,17 @@ class JournalSession:
     def logout(self):
         logout_url = "%s/log-out" % self._host
         LOGGER.info("Logging out at %s", logout_url)
-        logged_in_page = self._browser.get(logout_url)
-        _assert_html_response(logged_in_page)
+        logged_out_page = self._browser.get(logout_url)
+        LOGGER.info("Redirected to %s after log out", logged_out_page.url)
+        _assert_html_response(logged_out_page)
 
-        profile = logged_in_page.soup.select_one(self.PROFILE_LINK)
-        assert profile is None, ("Found %s in %s response\n%s" % (self.PROFILE_LINK, logged_in_page.status_code, logged_in_page.content))
-
+        profile = logged_out_page.soup.select_one(self.PROFILE_LINK)
+        assert profile is None, ("Found %s in %s response\n%s" % (self.PROFILE_LINK, logged_out_page.status_code, logged_out_page.content))
 
     def check(self, page_path):
-        page = self._browser.get("%s/%s" % (self._host, page_path.lstrip('/')))
+        url = "%s/%s" % (self._host, page_path.lstrip('/'))
+        LOGGER.info("Visiting %s", url)
+        page = self._browser.get(url)
         _assert_html_response(page)
 
         return page

--- a/spectrum/input.py
+++ b/spectrum/input.py
@@ -217,6 +217,8 @@ class Journal:
         return JournalSession(self._host, browser)
 
 class JournalSession:
+    PROFILE_LINK = ".login-control__non_js_control_link"
+
     def __init__(self, host, browser):
         self._host = host
         self._browser = browser
@@ -233,10 +235,9 @@ class JournalSession:
         _assert_html_response(logged_in_page)
 
         # if changing to another check, move in logout()
-        profile_selector = ".login-control__non_js_control_link"
-        profile = logged_in_page.soup.select_one(profile_selector)
-        assert profile is not None, ("Cannot find %s in %s response\n%s" % (profile_selector, logged_in_page.status_code, logged_in_page.content))
-        LOGGER.info("Found logged-in profile button at %s", profile_selector)
+        profile = logged_in_page.soup.select_one(self.PROFILE_LINK)
+        assert profile is not None, ("Cannot find %s in %s response\n%s" % (self.PROFILE_LINK, logged_in_page.status_code, logged_in_page.content))
+        LOGGER.info("Found logged-in profile button at %s", self.PROFILE_LINK)
 
         return logged_in_page
 
@@ -246,9 +247,8 @@ class JournalSession:
         logged_in_page = self._browser.get(logout_url)
         _assert_html_response(logged_in_page)
 
-        profile_selector = ".login-control__non_js_control_link"
-        profile = logged_in_page.soup.select_one(profile_selector)
-        assert profile is None, ("Found %s in %s response\n%s" % (profile_selector, logged_in_page.status_code, logged_in_page.content))
+        profile = logged_in_page.soup.select_one(self.PROFILE_LINK)
+        assert profile is None, ("Found %s in %s response\n%s" % (self.PROFILE_LINK, logged_in_page.status_code, logged_in_page.content))
 
 
     def check(self, page_path):

--- a/spectrum/input.py
+++ b/spectrum/input.py
@@ -242,12 +242,14 @@ class JournalSession:
 
     def logout(self):
         logout_url = "%s/log-out" % self._host
+        LOGGER.info("Logging out at %s", logout_url)
         logged_in_page = self._browser.get(logout_url)
         _assert_html_response(logged_in_page)
 
         profile_selector = ".login-control__non_js_control_link"
         profile = logged_in_page.soup.select_one(profile_selector)
         assert profile is None, ("Found %s in %s response\n%s" % (profile_selector, logged_in_page.status_code, logged_in_page.content))
+
 
     def check(self, page_path):
         page = self._browser.get("%s/%s" % (self._host, page_path.lstrip('/')))

--- a/spectrum/input.py
+++ b/spectrum/input.py
@@ -221,14 +221,14 @@ class JournalSession:
         self._host = host
         self._browser = browser
 
-    def login(self):
-        self.enable_feature_flag()
-
+    # TODO: automatically pass Referer when MechanicalSoup is upgraded to allow it
+    def login(self, referer=None):
         login_url = "%s/log-in" % self._host
+        headers = {}
+        if referer:
+            headers['Referer'] = '%s%s' % (self._host, referer)
+        logged_in_page = self._browser.get(login_url, headers=headers)
         # should be automatically redirected back by simulator
-        #logged_in_page = self._browser.get(login_url)
-        # temporary Referer header to test redirect back to the original page
-        logged_in_page = self._browser.get(login_url, headers={'Referer': '%s/about' % self._host})
         _assert_html_response(logged_in_page)
 
         # if changing to another check, move in logout()

--- a/spectrum/test_journal.py
+++ b/spectrum/test_journal.py
@@ -68,7 +68,11 @@ def test_rss_feeds():
 @pytest.mark.annotations
 def test_logging_in_and_out():
     session = input.JOURNAL.session()
-    session.login()
+    session.enable_feature_flag()
+    session.check('/about')
+    returned_to = session.login(referer='/about')
+    print returned_to
+
     session.logout()
 
 @pytest.mark.journal
@@ -76,6 +80,7 @@ def test_logging_in_and_out():
 @pytest.mark.annotations
 def test_logged_in_profile():
     session = input.JOURNAL.session()
+    session.enable_feature_flag()
     session.login()
 
     id = _find_profile_id_by_orcid(MAGIC_ORCID)
@@ -86,6 +91,7 @@ def test_logged_in_profile():
 @pytest.mark.annotations
 def test_public_profile():
     profile_creation_session = input.JOURNAL.session()
+    profile_creation_session.enable_feature_flag()
     profile_creation_session.login()
 
     anonymous_session = input.JOURNAL.session()

--- a/spectrum/test_journal.py
+++ b/spectrum/test_journal.py
@@ -69,9 +69,10 @@ def test_rss_feeds():
 def test_logging_in_and_out():
     session = input.JOURNAL.session()
     session.enable_feature_flag()
-    session.check('/about')
-    returned_to = session.login(referer='/about')
-    print returned_to
+    original = '/about'
+    session.check(original)
+    returned_to = session.login(referer=original)
+    assert '/about' in returned_to.url, "Did not come back to the original page after log in"
 
     session.logout()
 


### PR DESCRIPTION
```
spectrum/test_journal.py [2018-01-30 14:00:32,818][INFO][spectrum.input][] Visiting https://end2end--journal.elifesciences.org/about
[2018-01-30 14:00:33,044][INFO][spectrum.input][] Logging in at https://end2end--journal.elifesciences.org/log-in (headers {'Referer': 'https://end2end--journal.elifesciences.org/about'})
[2018-01-30 14:00:34,931][INFO][spectrum.input][] Redirected to https://end2end--journal.elifesciences.org/about after log in
[2018-01-30 14:00:34,933][INFO][spectrum.input][] Found logged-in profile button at .login-control__non_js_control_link
[2018-01-30 14:00:34,933][INFO][spectrum.input][] Logging out at https://end2end--journal.elifesciences.org/log-out
[2018-01-30 14:00:35,412][INFO][spectrum.input][] Redirected to https://end2end--journal.elifesciences.org/ after log out
```