### PR TITLE
Remove feature flag

### DIFF
--- a/spectrum/input.py
+++ b/spectrum/input.py
@@ -260,11 +260,6 @@ class JournalSession:
 
         return page
 
-    def enable_feature_flag(self):
-        feature_flag = "%s/?open-sesame" % self._host
-        flagged_page = self._browser.get(feature_flag)
-        _assert_html_response(flagged_page)
-
 def invented_word(length=30, characters=None):
     if not characters:
         characters = string.ascii_lowercase + string.digits

--- a/spectrum/test_journal.py
+++ b/spectrum/test_journal.py
@@ -68,7 +68,6 @@ def test_rss_feeds():
 @pytest.mark.annotations
 def test_logging_in_and_out():
     session = input.JOURNAL.session()
-    session.enable_feature_flag()
     original = '/about'
     session.check(original)
     returned_to = session.login(referer=original)
@@ -81,7 +80,6 @@ def test_logging_in_and_out():
 @pytest.mark.annotations
 def test_logged_in_profile():
     session = input.JOURNAL.session()
-    session.enable_feature_flag()
     session.login()
 
     id = _find_profile_id_by_orcid(MAGIC_ORCID)
@@ -92,11 +90,9 @@ def test_logged_in_profile():
 @pytest.mark.annotations
 def test_public_profile():
     profile_creation_session = input.JOURNAL.session()
-    profile_creation_session.enable_feature_flag()
     profile_creation_session.login()
 
     anonymous_session = input.JOURNAL.session()
-    anonymous_session.enable_feature_flag()
     profile_id = _find_profile_id_by_orcid(MAGIC_ORCID)
 
     anonymous_session.check('/profiles/%s' % profile_id)


### PR DESCRIPTION
Even when we'll use flags for other features, it's likely to be implemented on a per-user basis rather than with a query string.