### PR TITLE
ELPP-3447 Exponential backoff on 504 responses

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 apipkg==1.4
 appdirs==1.4.3
 astroid==1.4.5
+backoff==1.4.3
 beautifulsoup4==4.5.1
 boto==2.34.0
 boto3==1.4.2


### PR DESCRIPTION
Trying to use the generic `backoff` library since not all backoffs are done through `requests` (e.g. `boto` for S3 access), this could potentially substitute `polling` for other checks too (later on).