### PR TITLE
ELPP-3445 Change subject of an article through silent correction

### DIFF
--- a/spectrum/generator.py
+++ b/spectrum/generator.py
@@ -177,3 +177,20 @@ class ArticleZip:
         else:
             LOGGER.info("Not deleted directory %s because it doesn't exist", self._directory)
 
+def article_subjects(ids_to_subjects):
+    maximum_suffix = 999999999
+    suffix = random.randrange(1, maximum_suffix + 1)
+    generated_file_name = '%s/article_subjects_%s.csv' % (COMMON['tmp'], suffix)
+    with open(generated_file_name, 'w') as generated_file:
+        generated_file.write('DOI,subj-group-type,subject\n')
+        for id, subject in ids_to_subjects.items():
+            generated_file.write('10.7554/eLife.%s,heading,%s\n' % (id, subject))
+    return ArticleSubjects(generated_file_name)
+
+class ArticleSubjects:
+    def __init__(self, filename):
+        self._filename = filename
+
+    def filename(self):
+        return self._filename
+

--- a/spectrum/input.py
+++ b/spectrum/input.py
@@ -15,8 +15,10 @@ class InputBucket:
         self._s3 = s3
         self._bucket_name = bucket_name
 
-    def upload(self, filename, id):
-        self._s3.meta.client.upload_file(filename, self._bucket_name, path.basename(filename))
+    def upload(self, filename, destination_filename=None, id=None):
+        if not destination_filename:
+            destination_filename = path.basename(filename)
+        self._s3.meta.client.upload_file(filename, self._bucket_name, destination_filename)
         LOGGER.info("Uploaded %s to %s", filename, self._bucket_name, extra={'id': id})
 
     def clean(self, prefix=None):
@@ -298,3 +300,5 @@ BOT_WORKFLOWS = BotWorkflowStarter(
     SETTINGS['region_name'],
     SETTINGS['queue_workflow_starter']
 )
+
+BOT_CONFIGURATION = InputBucket(aws.S3, SETTINGS['bucket_configuration'])

--- a/spectrum/input.py
+++ b/spectrum/input.py
@@ -19,7 +19,7 @@ class InputBucket:
         if not destination_filename:
             destination_filename = path.basename(filename)
         self._s3.meta.client.upload_file(filename, self._bucket_name, destination_filename)
-        LOGGER.info("Uploaded %s to %s", filename, self._bucket_name, extra={'id': id})
+        LOGGER.info("Uploaded %s to %s/%s", filename, self._bucket_name, destination_filename, extra={'id': id})
 
     def clean(self, prefix=None):
         aws.clean_bucket(self._bucket_name, prefix)

--- a/spectrum/test_article.py
+++ b/spectrum/test_article.py
@@ -93,16 +93,16 @@ def test_article_silent_correction(generate_article, modify_article):
 @pytest.mark.continuum
 @pytest.mark.bot
 @pytest.mark.lax
-def test_article_subject_change(generate_article, modify_article):
+def test_article_subject_change(generate_article):
     template_id = 15893
     article = generate_article(template_id)
-    #_ingest_and_publish_and_wait_for_published(article)
-    ## TODO: for stability, wait until all the publishing workflows have finished. Github xml is enough
-    #checks.GITHUB_XML.article(id=article.id(), version=article.version(), text_match='cytomegalovirus')
+    _ingest_and_publish_and_wait_for_published(article)
+    # TODO: for stability, wait until all the publishing workflows have finished. Github xml is enough
+    checks.GITHUB_XML.article(id=article.id(), version=article.version(), text_match='cytomegalovirus')
 
     subjects_configuration = generator.article_subjects({article.id(): "Immunology"})
     input.BOT_CONFIGURATION.upload(subjects_configuration.filename())
-    #input.BOT_WORKFLOWS.change_subject_bad_name({article.id()})
+    _feed_silent_correction(article)
 
 @pytest.mark.continuum
 @pytest.mark.bot

--- a/spectrum/test_article.py
+++ b/spectrum/test_article.py
@@ -101,8 +101,10 @@ def test_article_subject_change(generate_article):
     checks.GITHUB_XML.article(id=article.id(), version=article.version(), text_match='cytomegalovirus')
 
     subjects_configuration = generator.article_subjects({article.id(): "Immunology"})
-    input.BOT_CONFIGURATION.upload(subjects_configuration.filename())
+    input.BOT_CONFIGURATION.upload(subjects_configuration.filename(), 'article_subjects.csv')
     _feed_silent_correction(article)
+    input.SILENT_CORRECTION.article(os.path.basename(article.filename()))
+    #checks.API.wait_article(id=article.id(), subjects='...')
 
 @pytest.mark.continuum
 @pytest.mark.bot
@@ -229,10 +231,10 @@ def test_rss_feed_contains_new_article(generate_article):
     checks.OBSERVER.latest_article(article.id())
 
 def _ingest(article):
-    input.PRODUCTION_BUCKET.upload(article.filename(), article.id())
+    input.PRODUCTION_BUCKET.upload(article.filename(), id=article.id())
 
 def _feed_silent_correction(article):
-    input.SILENT_CORRECTION_BUCKET.upload(article.filename(), article.id())
+    input.SILENT_CORRECTION_BUCKET.upload(article.filename(), id=article.id())
 
 def _wait_for_publishable(article, run_after):
     article_on_dashboard = checks.DASHBOARD.ready_to_publish(id=article.id(), version=article.version(), run_after=run_after)

--- a/spectrum/test_article.py
+++ b/spectrum/test_article.py
@@ -89,6 +89,21 @@ def test_article_silent_correction(generate_article, modify_article):
     checks.ARCHIVE.of(id=article.id(), version=article.version(), last_modified_after=silent_correction_start)
     checks.CDN_XML.of(text_match='CYTOMEGALOVIRUS', id=article.id(), version=article.version())
 
+@pytest.mark.journal
+@pytest.mark.continuum
+@pytest.mark.bot
+@pytest.mark.lax
+def test_article_subject_change(generate_article, modify_article):
+    template_id = 15893
+    article = generate_article(template_id)
+    #_ingest_and_publish_and_wait_for_published(article)
+    ## TODO: for stability, wait until all the publishing workflows have finished. Github xml is enough
+    #checks.GITHUB_XML.article(id=article.id(), version=article.version(), text_match='cytomegalovirus')
+
+    subjects_configuration = generator.article_subjects({article.id(): "Immunology"})
+    input.BOT_CONFIGURATION.upload(subjects_configuration.filename())
+    #input.BOT_WORKFLOWS.change_subject_bad_name({article.id()})
+
 @pytest.mark.continuum
 @pytest.mark.bot
 @pytest.mark.lax

--- a/spectrum/test_article.py
+++ b/spectrum/test_article.py
@@ -101,7 +101,7 @@ def test_article_subject_change(generate_article):
     checks.GITHUB_XML.article(id=article.id(), version=article.version(), text_match='cytomegalovirus')
 
     subjects_configuration = generator.article_subjects({article.id(): "Immunology"})
-    input.BOT_CONFIGURATION.upload(subjects_configuration.filename(), 'article_subjects.csv')
+    input.BOT_CONFIGURATION.upload(subjects_configuration.filename(), 'article_subjects_data/article_subjects.csv')
     _feed_silent_correction(article)
     input.SILENT_CORRECTION.article(os.path.basename(article.filename()))
     #checks.API.wait_article(id=article.id(), subjects='...')

--- a/spectrum/test_article.py
+++ b/spectrum/test_article.py
@@ -104,7 +104,7 @@ def test_article_subject_change(generate_article):
     input.BOT_CONFIGURATION.upload(subjects_configuration.filename(), 'article_subjects_data/article_subjects.csv')
     _feed_silent_correction(article)
     input.SILENT_CORRECTION.article(os.path.basename(article.filename()))
-    #checks.API.wait_article(id=article.id(), subjects='...')
+    checks.API.wait_article(id=article.id(), subjects=[{'name':'Immunology', 'id': 'immunology'}])
 
 @pytest.mark.continuum
 @pytest.mark.bot


### PR DESCRIPTION
I am using the article `elife-15893-v1` as a template.

The configuration file uploaded to `end2end-elife-bot` has:

```
$ cat article_subjects.csv 
DOI,subj-group-type,subject
10.7554/eLife.32656,heading,Biochemistry and Chemical Biology
```

but the subjects do not get rewritten:

```
curl -s https://end2end--gateway.elifesciences.org/articles/134820053256315893 | jq .subjects
[
  {
    "name": "Biochemistry",
    "id": "biochemistry"
  },
  {
    "name": "Biophysics and Structural Biology",
    "id": "biophysics-structural-biology"
  }
]
```

`worker.log` says:

```
2018-02-16T16:16:59Z INFO worker_1394 activityType: ModifyArticleSubjects
...
2018-02-16T16:16:59Z INFO worker_1394 did not modify any article subjects in the article xml
```

(the test is missing the assertion for now, I was doing the check manually)