### PR TITLE
ELPP-3393 Add test to log in through journal's CDN

### DIFF
--- a/spectrum/input.py
+++ b/spectrum/input.py
@@ -192,12 +192,17 @@ def _journal_cms_page_title(soup):
     return soup.find("h1", {"class": "page-title"}).text.strip()
 
 class Journal:
-    def __init__(self, host):
+    def __init__(self, host, cdn_host):
         self._host = host
+        self._cdn_host = cdn_host
 
     def session(self):
         browser = mechanicalsoup.Browser()
         return JournalSession(self._host, browser)
+
+    def cdn_session(self):
+        browser = mechanicalsoup.Browser()
+        return JournalSession(self._cdn_host, browser)
 
 class JournalSession:
     PROFILE_LINK = ".login-control__non_js_control_link"
@@ -264,6 +269,7 @@ JOURNAL_CMS = JournalCms(
 
 JOURNAL = Journal(
     SETTINGS['journal_host'],
+    SETTINGS['journal_cdn_host'],
 )
 
 BOT_WORKFLOWS = BotWorkflowStarter(

--- a/spectrum/test_journal.py
+++ b/spectrum/test_journal.py
@@ -88,6 +88,16 @@ def test_logged_in_profile():
 @pytest.mark.journal
 @pytest.mark.profiles
 @pytest.mark.annotations
+def test_logged_in_through_cdn():
+    session = input.JOURNAL.cdn_session()
+    session.login()
+
+    id = _find_profile_id_by_orcid(MAGIC_ORCID)
+    session.check('/profiles/%s' % id)
+
+@pytest.mark.journal
+@pytest.mark.profiles
+@pytest.mark.annotations
 def test_public_profile():
     profile_creation_session = input.JOURNAL.session()
     profile_creation_session.login()


### PR DESCRIPTION
Sample logs
```
spectrum/test_journal.py [2018-06-13 10:46:00,454][INFO][spectrum.input][] Logging in at https://end2end--cdn-journal.elifesciences.org/log
-in (headers {})
[2018-06-13 10:46:04,124][INFO][spectrum.input][] Redirected to https://end2end--cdn-journal.elifesciences.org/ after log in
[2018-06-13 10:46:04,125][INFO][spectrum.input][] Found logged-in profile button at .login-control__non_js_control_link
[2018-06-13 10:46:04,673][INFO][spectrum.checks][] Found https://end2end--gateway.elifesciences.org/profiles: 200
[2018-06-13 10:46:04,674][INFO][spectrum.input][] Loading page /profiles/yvc20pqz
.

===================== 1 passed in 6.52 seconds ======================
```

This hits CloudFront at the moment, it will hit Fastly after porting.