### PR TITLE
ELPP-3732 Test journal redirects

### DIFF
--- a/spectrum/checks.py
+++ b/spectrum/checks.py
@@ -568,6 +568,15 @@ class JournalCheck:
         _assert_status_code(response, 200, url)
         return response
 
+    def redirect(self, path, expected, status_code=301):
+        url = _build_url(path, self._host)
+        LOGGER.info("Loading %s", url)
+        response = requests.get(url, allow_redirects=False)
+        _assert_status_code(response, status_code, url)
+        location = response.headers['Location']
+        assert location.startswith(self._host)
+        assert location == ('%s%s' % (self._host, expected))
+
     def listing(self, path):
         body = self.generic(path)
         soup = BeautifulSoup(body, "html.parser")

--- a/spectrum/test_journal.py
+++ b/spectrum/test_journal.py
@@ -28,6 +28,10 @@ def test_magazine():
 def test_various_generic_pages(path):
     checks.JOURNAL.generic(path)
 
+@pytest.mark.journal
+def test_redirects():
+    checks.JOURNAL_CDN.redirect('/content/4/e10627v1?param=value', '/articles/10627v1?param=value')
+
 @pytest.mark.two
 @pytest.mark.journal
 @pytest.mark.journal_cms


### PR DESCRIPTION
End2end is the first environment where the whole PHP + Nginx + CDN is available.

Currently should fail:
```
E       assert <built-in method startswith of str object at 0x7ff34ad958f0>('https://end2end--cdn-journal.elifesciences.org')
E        +  where <built-in method startswith of str object at 0x7ff34ad958f0> = 'http://end2end--journal.elifesciences.org/articles/10627v1?param=value'.startswith
E        +  and   'https://end2end--cdn-journal.elifesciences.org' = 'https://end2end--cdn-journal.elifesciences.org'
E        +    where 'https://end2end--cdn-journal.elifesciences.org' = <spectrum.checks.JournalCheck instance at 0x7ff34ae931b8>._host
```