### PR TITLE
Add empty test for digests API

### DIFF
--- a/spectrum/checks.py
+++ b/spectrum/checks.py
@@ -326,6 +326,9 @@ class ApiCheck:
     def annotations(self, profile_id, access='public'):
         return self._list_api('/annotations?by=%s&access=%s' % (profile_id, access), 'annotation')
 
+    def digests(self):
+        return self._list_api('/digests', 'digest')
+
     def _list_api(self, path, entity):
         url = "%s%s" % (self._host, path)
         response = requests.get(url, headers=self._base_headers({'Accept': 'application/vnd.elife.%s-list+json; version=1' % entity}))

--- a/spectrum/test_api.py
+++ b/spectrum/test_api.py
@@ -29,6 +29,11 @@ def test_list_based_apis_annotations():
     super_user_version = checks.API_SUPER_USER.annotations(any_profile, access='restricted')
     assert super_user_version['total'] > public_version['total']
 
+@pytest.mark.digests
+def test_list_based_apis_digests():
+    #checks.API.digests()
+    pass
+
 @pytest.mark.two
 @pytest.mark.search
 def test_search():


### PR DESCRIPTION
Just so that something runs with the marker `digests`, later we can turn on the call to the /digests API