### PR TITLE
Check also events of a run before believing `ready to publish`

### DIFF
--- a/spectrum/checks.py
+++ b/spectrum/checks.py
@@ -102,7 +102,14 @@ class DashboardArticleCheck:
         self._password = password
 
     def ready_to_publish(self, id, version, run=None, run_after=None):
-        article_on_dashboard = self._wait_for_status(id, version, run=run, status="ready to publish", run_after=run_after)
+        # it is not enough to wait for the "ready to publish" state because
+        # when ingesting a run 2 for a particular version, the article is still
+        # in "ready to publish" from run 1. This is a problem of the dashboard
+        # that should change into "not ready to publish, if you press the button
+        # now it will break everything".
+        # We can't change the dashboard easily because it's a warzone
+        # so we will pass an additional check on the current run instead.
+        article_on_dashboard = self._wait_for_status(id, version, run=run, status="ready to publish", run_after=run_after, run_contains_events=['Ready To Publish'])
         current_version = article_on_dashboard['versions'][str(version)]
         preview_link = current_version['details']['preview-link']
         LOGGER.info("Found preview-link on dashboard: %s", preview_link)
@@ -122,9 +129,9 @@ class DashboardArticleCheck:
             version, self._host, id
         )
 
-    def _wait_for_status(self, id, version, status, run=None, run_after=None):
+    def _wait_for_status(self, id, version, status, run=None, run_after=None, run_contains_events=None):
         return _poll(
-            lambda: self._is_present(id, version, status, run=run, run_after=run_after),
+            lambda: self._is_present(id, version, status, run=run, run_after=run_after, run_contains_events=run_contains_events),
             lambda: "article version %s in status %s on dashboard (run filter %s, run_after filter %s): %s/api/article/%s",
             version,
             status,
@@ -134,7 +141,7 @@ class DashboardArticleCheck:
             id
         )
 
-    def _is_present(self, id, version, status, run=None, run_after=None):
+    def _is_present(self, id, version, status, run=None, run_after=None, run_contains_events=None):
         def _extract_run_contents(version_contents):
             if not version_contents:
                 return False, article
@@ -151,8 +158,12 @@ class DashboardArticleCheck:
                 run_contents = self._check_for_run(version_contents)
             if not run_contents:
                 return False, version_contents
+            if run_contains_events:
+                for important_event in run_contains_events:
+                    if important_event not in [e['event-type'] for e in run_contents['events']]:
+                        return False, run_contents
 
-            self._check_correctness(run_contents)
+            self._ensure_no_unrecoverable_errors(run_contents)
 
             return True, run_contents
 
@@ -171,11 +182,12 @@ class DashboardArticleCheck:
             else:
                 run_contents = dump
             LOGGER.info(
-                "Found %s version %s in status %s on dashboard with run %s",
+                "Found %s version %s in status %s on dashboard with run %s (required: events: %s)",
                 url,
                 version,
                 status,
                 run_contents['run-id'],
+                run_contains_events,
                 extra={'id': id}
             )
             return article
@@ -210,7 +222,7 @@ class DashboardArticleCheck:
             return False
         return matching_runs[0]
 
-    def _check_correctness(self, run_contents):
+    def _ensure_no_unrecoverable_errors(self, run_contents):
         errors = [e for e in run_contents['events'] if e['event-status'] == 'error']
         if errors:
             raise UnrecoverableError("At least one error event was reported for the run.\n%s" % pformat(errors))


### PR DESCRIPTION
```
[2018-08-02 17:20:37,352][INFO][spectrum.checks][1777256512047515893] Found https://end2end--ppp-dash.elifesciences.org/api/article/1777256512047515893 version 1 in status ready to publish on dashboard with run b3d50b2e-c1bf-4c4d-83ac-2bff6cefab48 (required: events: ['Ready To Publish'])
```

Caused https://alfred.elifesciences.org/job/test-journal/1542/