### PR TITLE
Try milestone step to abort old builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,10 +4,12 @@ elifePipeline {
         checkout scm
         commit = elifeGitRevision()
     }
+    milestone label: 'checkout'
 
     stage 'End2end tests run', {
         elifeSpectrum(environmentName: 'end2end', processes: 15, revision: commit)
     }
+    milestone label: 'end2end-tests'
 
     stage 'Quick load test', {
         elifeLoad(environmentName: 'end2end', revision: commit)


### PR DESCRIPTION
4 builds started, if my calculations are correct a new one superceding the older ones should make those abort (saving time albeit losing the result of intermediate commits).