### PR TITLE
Test digests on silent corrections

### DIFF
--- a/spectrum/articles.py
+++ b/spectrum/articles.py
@@ -21,3 +21,6 @@ def wait_for_publishable(article, run_after):
 
 def publish(article, run):
     input.DASHBOARD.publish(id=article.id(), version=article.version(), run=run)
+
+def feed_silent_correction(article):
+    input.SILENT_CORRECTION_BUCKET.upload(article.filename(), id=article.id())

--- a/spectrum/test_article.py
+++ b/spectrum/test_article.py
@@ -103,7 +103,7 @@ def test_article_silent_correction(generate_article, modify_article):
 
     silent_correction_start = datetime.now()
     silently_corrected_article = modify_article(article, replacements={'cytomegalovirus': 'CYTOMEGALOVIRUS'})
-    _feed_silent_correction(silently_corrected_article)
+    articles.feed_silent_correction(silently_corrected_article)
     checks.API.wait_article(id=article.id(), title='Correction: Human CYTOMEGALOVIRUS IE1 alters the higher-order chromatin structure by targeting the acidic patch of the nucleosome')
     checks.GITHUB_XML.article(id=article.id(), version=article.version(), text_match='CYTOMEGALOVIRUS')
     checks.ARCHIVE.of(id=article.id(), version=article.version(), last_modified_after=silent_correction_start)
@@ -121,7 +121,7 @@ def test_article_subject_change(generate_article):
 
     subjects_configuration = generator.article_subjects({article.id(): "Immunology"})
     input.BOT_CONFIGURATION.upload(subjects_configuration.filename(), 'article_subjects_data/article_subjects.csv')
-    _feed_silent_correction(article)
+    articles.feed_silent_correction(article)
     checks.API.wait_article(id=article.id(), subjects=[{'name':'Immunology', 'id': 'immunology'}])
     # are there caches that need to expire first?
     checks.JOURNAL.article_only_subject(id=article.id(), version=article.version(), subject_id='immunology')
@@ -271,9 +271,6 @@ def test_rss_feed_contains_new_article(generate_article):
     article = generate_article(SIMPLEST_ARTICLE_ID)
     _ingest_and_publish_and_wait_for_published(article)
     checks.OBSERVER.latest_article(article.id())
-
-def _feed_silent_correction(article):
-    input.SILENT_CORRECTION_BUCKET.upload(article.filename(), id=article.id())
 
 def _wait_for_published(article):
     checks.DASHBOARD.published(id=article.id(), version=article.version())

--- a/spectrum/test_digest.py
+++ b/spectrum/test_digest.py
@@ -8,7 +8,8 @@ DIGEST_ARTICLE_ID = '00790'
 
 @pytest.mark.bot
 @pytest.mark.digests
-def test_digest_lifecycle(generate_digest, generate_article):
+def test_digest_lifecycle(generate_digest, generate_article, modify_article):
+    # digest ingestion
     digest = generate_digest(DIGEST_ARTICLE_ID)
     input.DIGESTS_BUCKET.upload(digest.filename(), id=digest.article_id())
     checks.BOT_EMAILS.wait_email(subject='Digest: Anonymous_%s' % digest.article_id())
@@ -16,11 +17,19 @@ def test_digest_lifecycle(generate_digest, generate_article):
     checks.BOT_INTERNAL_DIGEST_OUTBOX_JPG.of(id=digest.article_id())
     #checks.DIGEST_JPG_PUBLISHED_CDN_BUCKET.of(id=digest.article_id())
 
+    # article ingestion
     article = generate_article(template_id=DIGEST_ARTICLE_ID, article_id=digest.article_id())
     ingestion_start = datetime.now()
     articles.ingest(article)
     run = articles.wait_for_publishable(article, ingestion_start)
     checks.API_SUPER_USER.digest(id=article.id())
+
+    # article publishing
     articles.publish(article, run)
     checks.API.wait_digest(id=article.id())
     checks.JOURNAL.digest(id=article.id())
+
+    # silent correction after publication
+    silently_corrected_article = modify_article(article, replacements={'outcompetes': 'OUTCOMPETES'})
+    articles.feed_silent_correction(silently_corrected_article)
+    checks.API.wait_article(id=article.id(), title='Fungal effector Ecp6 OUTCOMPETES host immune receptor for chitin binding through intrachain LysM dimerization')

--- a/spectrum/test_digest.py
+++ b/spectrum/test_digest.py
@@ -30,6 +30,7 @@ def test_digest_lifecycle(generate_digest, generate_article, modify_article):
     checks.JOURNAL.digest(id=article.id())
 
     # silent correction after publication
-    silently_corrected_article = modify_article(article, replacements={'outcompetes': 'OUTCOMPETES'})
+    silently_corrected_article = modify_article(article, replacements={'outcompetes': 'OUTCOMPETES', 'Chitin': 'CHITIN'})
     articles.feed_silent_correction(silently_corrected_article)
     checks.API.wait_article(id=article.id(), title='Fungal effector Ecp6 OUTCOMPETES host immune receptor for chitin binding through intrachain LysM dimerization')
+    checks.API.wait_digest(id=article.id(), item_check=checks.API.item_check_content('CHITIN'))

--- a/spectrum/test_digest.py
+++ b/spectrum/test_digest.py
@@ -15,7 +15,7 @@ def test_digest_lifecycle(generate_digest, generate_article, modify_article):
     checks.BOT_EMAILS.wait_email(subject='Digest: Anonymous_%s' % digest.article_id())
     checks.BOT_INTERNAL_DIGEST_OUTBOX_DOC.of(id=digest.article_id())
     checks.BOT_INTERNAL_DIGEST_OUTBOX_JPG.of(id=digest.article_id())
-    #checks.DIGEST_JPG_PUBLISHED_CDN_BUCKET.of(id=digest.article_id())
+    checks.DIGEST_JPG_PUBLISHED_CDN_BUCKET.of(id=digest.article_id())
 
     # article ingestion
     article = generate_article(template_id=DIGEST_ARTICLE_ID, article_id=digest.article_id())


### PR DESCRIPTION
For https://github.com/elifesciences/issues/issues/4462

- Enable check on digest published image (unrelated)
- Add silent correction of an article with a digest
- Add check for digest text modification coming from article