### PR TITLE
Correctly expect only a result when polling for mail messages

### DIFF
--- a/spectrum/mailcatcher.py
+++ b/spectrum/mailcatcher.py
@@ -25,5 +25,5 @@ class MailcatcherCheck():
         #   "size": "51975",
         #   "created_at": "2018-07-31T13:52:22+00:00"
         # }]
-        (_, matching) = polling.poll(_check, "Cannot find email with subject %s", subject)
+        matching = polling.poll(_check, "Cannot find email with subject %s", subject)
         LOGGER.info("Found matching messages: %s", matching)

--- a/spectrum/polling.py
+++ b/spectrum/polling.py
@@ -14,7 +14,7 @@ GLOBAL_TIMEOUT = int(os.environ['SPECTRUM_TIMEOUT']) if 'SPECTRUM_TIMEOUT' in os
 
 def poll(action_fn, error_message, *error_message_args):
     """
-    Poll until action_fn returns something truthy. After GLOBAL_TIMEOUT throws an exception.
+    Poll until action_fn returns something truthy. After GLOBAL_TIMEOUT throw an exception.
 
     action_fn may return:
     - a tuple: first element is a result (truthy or falsy), second element any detail


### PR DESCRIPTION
Tuples are used internally to pair together a `(result, details)` while polling, but if no errors are encountered only `result` is exposed.