### PR TITLE
Use journal's CDN when testing integration with xpub

### DIFF
--- a/spectrum/input.py
+++ b/spectrum/input.py
@@ -197,20 +197,13 @@ def _journal_cms_page_title(soup):
     return soup.find("h1", {"class": "page-title"}).text.strip()
 
 class Journal:
-    def __init__(self, host, cdn_host):
+    def __init__(self, host):
         self._host = host
-        self._cdn_host = cdn_host
 
     def session(self):
         browser = mechanicalsoup.Browser()
         return JournalHtmlSession(self._host, browser)
 
-    def cdn_session(self):
-        browser = mechanicalsoup.Browser()
-        return JournalHtmlSession(self._cdn_host, browser)
-
-    # TODO: rename
-    # TODO: allow CDN
     def javascript_session(self, driver):
         return JournalJavaScriptSession(driver, self._host)
 
@@ -311,8 +304,11 @@ JOURNAL_CMS = JournalCms(
 )
 
 JOURNAL = Journal(
-    SETTINGS['journal_host'],
-    SETTINGS['journal_cdn_host'],
+    SETTINGS['journal_host']
+)
+
+JOURNAL_CDN = Journal(
+    SETTINGS['journal_cdn_host']
 )
 
 BOT_WORKFLOWS = BotWorkflowStarter(

--- a/spectrum/test_journal.py
+++ b/spectrum/test_journal.py
@@ -93,7 +93,7 @@ def test_logged_in_profile():
 @pytest.mark.profiles
 @pytest.mark.annotations
 def test_logged_in_through_cdn():
-    session = input.JOURNAL.cdn_session()
+    session = input.JOURNAL_CDN.session()
     session.login()
 
     id = _find_profile_id_by_orcid(MAGIC_ORCID)

--- a/spectrum/test_xpub.py
+++ b/spectrum/test_xpub.py
@@ -6,7 +6,7 @@ from spectrum import input
 @pytest.mark.profiles
 @pytest.mark.xpub
 def test_login(get_selenium_driver):
-    journal_session = input.JOURNAL.javascript_session(get_selenium_driver())
+    journal_session = input.JOURNAL_CDN.javascript_session(get_selenium_driver())
     xpub_session = journal_session.submit()
     xpub_session.login()
 
@@ -14,7 +14,7 @@ def test_login(get_selenium_driver):
 #@pytest.mark.journal_cms
 @pytest.mark.xpub
 def test_initial_submission(get_selenium_driver):
-    journal_session = input.JOURNAL.javascript_session(get_selenium_driver())
+    journal_session = input.JOURNAL_CDN.javascript_session(get_selenium_driver())
     xpub_session = journal_session.submit()
     xpub_session.login()
 


### PR DESCRIPTION
Also getting closer to the behavior of https://github.com/elifesciences/builder/pull/430 which needs the CDN to appear.