### PR TITLE
Remove medium service tests

### DIFF
--- a/spectrum/checks.py
+++ b/spectrum/checks.py
@@ -319,9 +319,6 @@ class ApiCheck:
     def people(self):
         self._list_api('/people', 'person')
 
-    def medium_articles(self):
-        self._list_api('/medium-articles', 'medium-article')
-
     def blog_articles(self):
         self._list_api('/blog-articles', 'blog-article')
 

--- a/spectrum/test_api.py
+++ b/spectrum/test_api.py
@@ -14,10 +14,6 @@ def test_list_based_apis_journal_cms():
     checks.API.interviews()
     checks.API.collections()
 
-@pytest.mark.medium
-def test_list_based_apis_medium():
-    checks.API.medium_articles()
-
 @pytest.mark.profiles
 def test_list_based_apis_profiles():
     checks.API.profiles()

--- a/spectrum/test_journal.py
+++ b/spectrum/test_journal.py
@@ -16,7 +16,6 @@ def test_homepage():
 @pytest.mark.two
 @pytest.mark.journal
 @pytest.mark.journal_cms
-@pytest.mark.medium
 @pytest.mark.search
 def test_magazine():
     checks.JOURNAL.magazine()


### PR DESCRIPTION
Part of https://github.com/elifesciences/issues/issues/4291 but spawned because `medium--end2end` was discovered as being broken as part of https://github.com/elifesciences/issues/issues/4558.