### PR TITLE
Update elife-15893 template with current subjects

### DIFF
--- a/spectrum/templates/elife-15893-vor-r1/elife-15893.xml.jinja
+++ b/spectrum/templates/elife-15893-vor-r1/elife-15893.xml.jinja
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.1d3 20150301//EN" "JATS-archivearticle1.dtd">
-<article xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" article-type="correction" dtd-version="1.1d3">
+<article xmlns:xlink="http://www.w3.org/1999/xlink" article-type="correction" dtd-version="1.1d3">
   <front>
     <journal-meta>
       <journal-id journal-id-type="nlm-ta">elife</journal-id>
@@ -9,7 +9,7 @@
       <journal-title-group>
         <journal-title>eLife</journal-title>
       </journal-title-group>
-      <issn publication-format="electronic" pub-type="epub">2050-084X</issn>
+      <issn pub-type="epub" publication-format="electronic">2050-084X</issn>
       <publisher>
         <publisher-name>eLife Sciences Publications, Ltd</publisher-name>
       </publisher>
@@ -22,10 +22,10 @@
           <subject>Correction</subject>
         </subj-group>
         <subj-group subj-group-type="heading">
-          <subject>Biochemistry</subject>
+          <subject>Biochemistry and Chemical Biology</subject>
         </subj-group>
         <subj-group subj-group-type="heading">
-          <subject>Biophysics and Structural Biology</subject>
+          <subject>Structural Biology and Molecular Biophysics</subject>
         </subj-group>
       </article-categories>
       <title-group>
@@ -76,7 +76,7 @@
           <contrib-id contrib-id-type="orcid">http://orcid.org/0000-0002-6537-4623</contrib-id>
         </contrib>
       </contrib-group>
-      <pub-date publication-format="electronic" date-type="pub">
+      <pub-date date-type="pub" publication-format="electronic">
         <day>14</day>
         <month>03</month>
         <year>2016</year>
@@ -106,7 +106,7 @@
           <license-p>This article is distributed under the terms of the <ext-link ext-link-type="uri" xlink:href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution License</ext-link>, which permits unrestricted use and redistribution provided that the original author and source are credited.</license-p>
         </license>
       </permissions>
-      <related-article ext-link-type="doi" related-article-type="corrected-article" xlink:href="10.7554/eLife.11911" id="ra1"/>
+      <related-article ext-link-type="doi" id="ra1" related-article-type="corrected-article" xlink:href="10.7554/eLife.11911"/>
       <custom-meta-group>
         <custom-meta>
           <meta-name>elife-xml-version</meta-name>


### PR DESCRIPTION
For https://github.com/elifesciences/issues/issues/4858

The article has been modified during its history to map it to new subjects. One old subject doesn't exist anymore in `personalised-covers`, hence we need the latest version to be able to run it through the publication pipeline.