### PR TITLE
create_podcast_episode breaks when inline_entity_form is updated

### DIFF
--- a/spectrum/input.py
+++ b/spectrum/input.py
@@ -106,7 +106,11 @@ class JournalCmsSession:
         LOGGER.info("Attaching image")
 
         form.input({'field_episode_mp3[0][uri]': uri})
-        form.input({'field_episode_chapter[form][inline_entity_form][title][0][value]': chapter_title})
+        chapter_title_field = create_page.soup.form.find('input', {'name': 'field_episode_chapter[form][0][title][0][value]'})
+        # Leave this condition in until after inline_entity_form is updated
+        if chapter_title_field is None:
+            chapter_title_field = create_page.soup.form.find('input', {'name': 'field_episode_chapter[form][inline_entity_form][title][0][value]'})
+        chapter_title_field['value'] = chapter_title
 
         response = self._browser.submit(form, create_page.url, data={'op': 'Save'})
         # requests follows redirects by default


### PR DESCRIPTION
See: https://github.com/elifesciences/journal-cms/pull/620

This change will allow the test to work before and after the `inline_entity_form` update. The test coverage remains the same and once the above PR is merged and deployed I will create a followup PR to remove the condition.