### PR TITLE
journal, disables tests that require logging in through orcid.

### DIFF
--- a/example-local-test.sh
+++ b/example-local-test.sh
@@ -8,4 +8,4 @@ export SPECTRUM_LOG_LEVEL=DEBUG  # more output
 export SPECTRUM_TIMEOUT=60  # speeds up errors
 
 #python -m pytest -s spectrum/test_api.py
-python -m pytest -vvv -s spectrum/test_article.py::test_bioprotocol_has_protocol_data
+python -m pytest -vvv -s spectrum/test_journal.py::test_public_profile

--- a/spectrum/test_api.py
+++ b/spectrum/test_api.py
@@ -18,6 +18,7 @@ def test_list_based_apis_journal_cms():
 def test_list_based_apis_profiles():
     checks.API.profiles()
 
+@pytest.mark.skip(reason="ORCID referer redirect behaviour has changed")
 @pytest.mark.annotations
 def test_list_based_apis_annotations():
     any_profile = 'jcarberry'

--- a/spectrum/test_journal.py
+++ b/spectrum/test_journal.py
@@ -2,6 +2,7 @@
 import pytest
 from spectrum import checks, input
 
+# 'Josiah Carberry', a dummy user used by ORCID
 MAGIC_ORCID = '0000-0002-1825-0097'
 
 @pytest.mark.two

--- a/spectrum/test_journal.py
+++ b/spectrum/test_journal.py
@@ -69,6 +69,7 @@ def test_rss_feeds():
 @pytest.mark.journal
 @pytest.mark.profiles
 @pytest.mark.annotations
+@pytest.mark.skip(reason="ORCID referer redirect behaviour has changed")
 def test_logging_in_and_out():
     session = input.JOURNAL.session()
     original = '/about'
@@ -81,6 +82,7 @@ def test_logging_in_and_out():
 @pytest.mark.journal
 @pytest.mark.profiles
 @pytest.mark.annotations
+@pytest.mark.skip(reason="ORCID referer redirect behaviour has changed")
 def test_logged_in_profile():
     session = input.JOURNAL.session()
     session.login()
@@ -91,6 +93,7 @@ def test_logged_in_profile():
 @pytest.mark.journal
 @pytest.mark.profiles
 @pytest.mark.annotations
+@pytest.mark.skip(reason="ORCID referer redirect behaviour has changed")
 def test_logged_in_through_cdn():
     session = input.JOURNAL_CDN.session()
     session.login()
@@ -101,6 +104,7 @@ def test_logged_in_through_cdn():
 @pytest.mark.journal
 @pytest.mark.profiles
 @pytest.mark.annotations
+@pytest.mark.skip(reason="ORCID referer redirect behaviour has changed")
 def test_public_profile():
     profile_creation_session = input.JOURNAL.session()
     profile_creation_session.login()


### PR DESCRIPTION
orcid's referer redirect behaviour has changed.