### PR TITLE
Corrected MSA Developmental Biology in 00625.

### DIFF
--- a/spectrum/templates/elife-00625-vor-r1/elife-00625.xml.jinja
+++ b/spectrum/templates/elife-00625-vor-r1/elife-00625.xml.jinja
@@ -22,7 +22,7 @@
           <subject>Insight</subject>
         </subj-group>
         <subj-group subj-group-type="heading">
-          <subject>Developmental Biology and Stem Cells</subject>
+          <subject>Developmental Biology</subject>
         </subj-group>
         <subj-group subj-group-type="heading">
           <subject>Plant Biology</subject>


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/6586

This should fix the personalised covers generation bug related to an old Major Subject Area (MSA) value in an article XML template file.