### PR TITLE
retries.py, adds 404 as a case that should be retried.

### DIFF
--- a/spectrum/retries.py
+++ b/spectrum/retries.py
@@ -10,7 +10,14 @@ LOGGER = logger.logger(__name__)
 
 
 def retry_request(response):
-    return response.status_code in [502, 504]
+    retry_these = [
+        # lsh@2021-07-27: added as there appears to be a case in the interaction of iiif and journal-cms
+        # where journal-cms doesn't have the image ready.
+        404,
+        502,
+        504
+    ]
+    return response.status_code in retry_these
 
 
 def _retrying_request(details):


### PR DESCRIPTION
I intend for this to be temporary until the root cause of the problem is found. In the interim this *may* allow some time-expensive tests to pass where they would otherwise have failed.