### PR TITLE
Remove article has_figures flag as test broken and currently blocking deployments

### DIFF
--- a/spectrum/checks.py
+++ b/spectrum/checks.py
@@ -554,7 +554,6 @@ class JournalCheck:
     CSS_PAGER_LINK = '.pager a'
     CSS_ASSET_VIEWER_DOWNLOAD_LINK = '.asset-viewer-inline__download_all_link'
     CSS_DOWNLOAD_LINK = '#downloads a'
-    CLASS_FIGURES_LINK = 'view-selector__link--figures'
     CLASS_SUBJECT_LINK = 'content-header__subject_link'
 
     def __init__(self, host, resource_checking_method='head', query_string=None, headers=None):
@@ -572,18 +571,12 @@ class JournalCheck:
     def with_headers(self, headers):
         return JournalCheck(self._host, self._resource_checking_method, self._query_string, headers)
 
-    def article(self, id, has_figures=False, version=None):
+    def article(self, id, version=None):
         url = _build_url("/articles/%s" % id, self._host)
         if version:
             url = "%sv%s" % (url, version)
         LOGGER.info("Loading %s", url, extra={'id':id})
         body = self.generic(url)
-        figures_page_links = self._links(body, self.CLASS_FIGURES_LINK)
-        if has_figures:
-            assert len(figures_page_links) == 1, "Expected a single figures page link with selector %s, found %s" % (self.CLASS_FIGURES_LINK, figures_page_links)
-            figures_url = _build_url(figures_page_links[0], self._host)
-            LOGGER.info("Loading figures page %s", figures_url, extra={'id':id})
-            self.generic(url)
         return body
 
     def article_only_subject(self, id, subject_id, version=None):

--- a/spectrum/generator.py
+++ b/spectrum/generator.py
@@ -206,9 +206,6 @@ class ArticleZip:
     def figure_names(self):
         return self._figure_names
 
-    def has_figures(self):
-        return len(self._figure_names) > 0
-
     def has_pdf(self):
         return self._has_pdf
 

--- a/spectrum/test_article.py
+++ b/spectrum/test_article.py
@@ -149,7 +149,7 @@ def test_article_with_unicode_content(generate_article):
     article = generate_article(template_id=19532)
     _ingest_and_publish(article)
     checks.API.wait_article(id=article.id())
-    journal_page = checks.JOURNAL.article(id=article.id(), has_figures=article.has_figures())
+    journal_page = checks.JOURNAL.article(id=article.id())
     assert "Szymon Łęski" in journal_page
 
 @pytest.mark.journal
@@ -325,8 +325,8 @@ def _wait_for_published(article):
 
     checks.ARCHIVE.of(id=article.id(), version=article.version())
     article_from_api = checks.API.article(id=article.id(), version=article.version())
-    checks.JOURNAL.article(id=article.id(), has_figures=article.has_figures())
-    checks.JOURNAL_CDN.article(id=article.id(), has_figures=article.has_figures())
+    checks.JOURNAL.article(id=article.id())
+    checks.JOURNAL_CDN.article(id=article.id())
     return article_from_api
 
 def _publish(article, run_after):


### PR DESCRIPTION
Improves: https://github.com/elifesciences/issues/issues/7433

The check that I'm removing was not working as intended. It should be re-introduced but as the main goal of the check wasn't being executed I was happy to remove it as the less valuable check to see that the figures url was present is already covered in the `journal` application tests and need not be a focus of end2end.

The more valuable check of ensuring that all of the assets load correctly on the figures page should be introduced and I will submit a followup PR to start us off on this. The current test failed to perform this check which is why I was happy to remove the code.

The following line of code should be `self.generic(figures_url)` rather than `self.generic(url)`:

https://github.com/elifesciences/elife-spectrum/blob/master/spectrum/checks.py#L586

The test in journal to verify that the figures url is present on the article page is here: https://github.com/elifesciences/journal/blob/d25840330f5fe0173c7a650fe0f53e92e03ffd16/test/Controller/ArticleControllerTest.php#L2870-L2873