### PR TITLE
Reintroduce check for figures page

### DIFF
--- a/spectrum/checks.py
+++ b/spectrum/checks.py
@@ -571,12 +571,16 @@ class JournalCheck:
     def with_headers(self, headers):
         return JournalCheck(self._host, self._resource_checking_method, self._query_string, headers)
 
-    def article(self, id, version=None):
+    def article(self, id, has_figures_page=False, version=None):
         url = _build_url("/articles/%s" % id, self._host)
         if version:
             url = "%sv%s" % (url, version)
         LOGGER.info("Loading %s", url, extra={'id':id})
         body = self.generic(url)
+        if has_figures_page:
+            figures_url = "%s/figures" % (url)
+            LOGGER.info("Loading figures page %s", figures_url, extra={'id':id})
+            self.generic(figures_url)
         return body
 
     def article_only_subject(self, id, subject_id, version=None):

--- a/spectrum/generator.py
+++ b/spectrum/generator.py
@@ -206,6 +206,9 @@ class ArticleZip:
     def figure_names(self):
         return self._figure_names
 
+    def has_figures_page(self):
+        return len(self._figure_names) > 0
+
     def has_pdf(self):
         return self._has_pdf
 

--- a/spectrum/test_article.py
+++ b/spectrum/test_article.py
@@ -149,7 +149,7 @@ def test_article_with_unicode_content(generate_article):
     article = generate_article(template_id=19532)
     _ingest_and_publish(article)
     checks.API.wait_article(id=article.id())
-    journal_page = checks.JOURNAL.article(id=article.id())
+    journal_page = checks.JOURNAL.article(id=article.id(), has_figures_page=article.has_figures_page())
     assert "Szymon Łęski" in journal_page
 
 @pytest.mark.journal
@@ -325,8 +325,8 @@ def _wait_for_published(article):
 
     checks.ARCHIVE.of(id=article.id(), version=article.version())
     article_from_api = checks.API.article(id=article.id(), version=article.version())
-    checks.JOURNAL.article(id=article.id())
-    checks.JOURNAL_CDN.article(id=article.id())
+    checks.JOURNAL.article(id=article.id(), has_figures_page=article.has_figures_page())
+    checks.JOURNAL_CDN.article(id=article.id(), has_figures_page=article.has_figures_page())
     return article_from_api
 
 def _publish(article, run_after):


### PR DESCRIPTION
This is a followup to: https://github.com/elifesciences/elife-spectrum/pull/314

This constructs the `figures_url` rather than checking for the link in the DOM which is being verified by the journal project.

This is the first time we will be performing checks on the Figures page as previously we were just checking for the presence of the figures link on the article page but mistakenly rechecking the article page.

I will indicate in the code where we need to add an additional check to verify that a figures page is expected.