### PR TITLE
Updated JATS4R URL in template XML comments.

### DIFF
--- a/spectrum/templates/elife-1234567890-vor-r1/elife-1234567890.xml.jinja
+++ b/spectrum/templates/elife-1234567890-vor-r1/elife-1234567890.xml.jinja
@@ -326,8 +326,8 @@ content must work as a discrete item on each author's roll over and on the displ
             <year>2016</year>
           </date>
           <!-- "preprint" or "pre-print"? Examples and text in JATS4R conflict:
-                         https://jats4r.org/article-publication-and-history-dates/#example-2
-                         https://jats4r.org/article-publication-and-history-dates/#comment-308 -->
+                         https://jats4r.niso.org/article-publication-and-history-dates/#example-2
+                         https://jats4r.niso.org/article-publication-and-history-dates/#comment-308 -->
           <self-uri content-type="preprint" xlink:href="http://doi.org/10.5555/12345678"/>
         </event>
       </pub-history>


### PR DESCRIPTION
Re issue https://github.com/elifesciences/issues/issues/8585

This is mentioned in XML comments only, the new URLs still work.